### PR TITLE
added 3D scatter plotly exporter, plus improved aesthetics for 2D exporter

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -5,5 +5,8 @@ PLOTLY_LOGO = os.path.abspath(os.path.join(os.path.dirname(__file__), 'logo.png'
 
 def setup():
     from glue.viewers.scatter.qt import ScatterViewer
+    from glue_vispy_viewers.scatter.scatter_viewer import VispyScatterViewer
     from . import html_exporters  # noqa
-    ScatterViewer.subtools['save'].append('save:plotly')
+    ScatterViewer.subtools['save'].append('save:plotly2d')
+    VispyScatterViewer.subtools['save'].append('save:plotly3d')
+

--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -10,3 +10,4 @@ def setup():
     ScatterViewer.subtools['save'].append('save:plotly2d')
     VispyScatterViewer.subtools['save'].append('save:plotly3d')
 
+

--- a/glue_plotly/html_exporters/__init__.py
+++ b/glue_plotly/html_exporters/__init__.py
@@ -1,1 +1,2 @@
 from . import scatter2d  # noqa
+from . import scatter3d  # noqa

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -16,45 +16,86 @@ import plotly.graph_objs as go
 class PlotlyScatter2DStaticExport(Tool):
 
     icon = PLOTLY_LOGO
-    tool_id = 'save:plotly'
+    tool_id = 'save:plotly2d'
     action_text = 'Save Plotly HTML page'
     tool_tip = 'Save Plotly HTML page'
 
     def activate(self):
 
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+        
+        width, height= np.array(self.viewer.figure.get_size_inches()*self.viewer.figure.dpi)[0], np.array(self.viewer.figure.get_size_inches()*self.viewer.figure.dpi)[1]
+        
+        layout = go.Layout(
+            margin=dict(r=50, l=50, b=50, t=50),  
+            width=1200,
+            height=1200*height/width, #scale axis correctly
+            xaxis=dict(
+                title=self.viewer.axes.get_xlabel(),
+                titlefont=dict(
+                    family='Arial, sans-serif',
+                    size=self.viewer.axes.xaxis.get_label().get_size(),
+                    color='black'
+                ),
+                showticklabels=True,
+                tickfont=dict(
+                    family='Arial, sans-serif',
+                    size=self.viewer.axes.xaxis.get_ticklabels()[0].get_fontsize(),
+                    color='black'),
+                range=[self.viewer.state.x_min,self.viewer.state.x_max]),
+            yaxis=dict(
+                title=self.viewer.axes.get_xlabel(),
+                titlefont=dict(
+                    family='Arial, sans-serif',
+                    size=self.viewer.axes.yaxis.get_label().get_size(),
+                    color='black'),
+                range=[self.viewer.state.y_min,self.viewer.state.y_max],
+                showticklabels=True,
+                tickfont=dict(
+                    family='Old Standard TT, serif',
+                    size=self.viewer.axes.yaxis.get_ticklabels()[0].get_fontsize(),
+                    color='black'),
+            )
+        )
 
-        fig = go.Figure(layout={'width': 800, 'height': 600})
+        fig = go.Figure(layout=layout)
 
         for layer_state in self.viewer.state.layers:
+        
+            if layer_state.visible==True:
 
-            marker = {}
+                marker = {}
 
-            x = layer_state.layer[self.viewer.state.x_att]
-            y = layer_state.layer[self.viewer.state.y_att]
+                x = layer_state.layer[self.viewer.state.x_att]
+                y = layer_state.layer[self.viewer.state.y_att]
 
-            if layer_state.cmap_mode == 'Fixed':
-                marker['color'] = layer_state.color
-            else:
-                marker['color'] = layer_state.layer[layer_state.cmap_att].copy()
-                marker['cmin'] = layer_state.cmap_vmin
-                marker['cmax'] = layer_state.cmap_vmin
-                marker['colorscale'] = layer_state.cmap.name.upper()
+                if layer_state.cmap_mode == 'Fixed':
+                    if layer_state.color!='0.35':
+                        marker['color'] = layer_state.color
+                    else:
+                        marker['color'] =   'gray'
+                else:
+                    marker['color'] = layer_state.layer[layer_state.cmap_att].copy()
+                    marker['cmin'] = layer_state.cmap_vmin
+                    marker['cmax'] = layer_state.cmap_vmin
+                    marker['colorscale'] = layer_state.cmap.name.upper()
+                    marker['color'][np.isnan(marker['color'])] = -np.inf
 
-            if layer_state.size_mode == 'Fixed':
-                marker['size'] = layer_state.size
-            else:
-                marker['size'] = 20 * (layer_state.layer[layer_state.size_att] - layer_state.size_vmin) / (layer_state.size_vmax - layer_state.size_vmin)
-                marker['sizemin'] = 5
 
-            marker['size'][np.isnan(marker['size'])] = 0
-            marker['size'][marker['size'] < 0] = 0
-            marker['color'][np.isnan(marker['color'])] = -np.inf
+                if layer_state.size_mode == 'Fixed':
+                    marker['size'] = layer_state.size
+                else:
+                    marker['size'] = 20 * (layer_state.layer[layer_state.size_att] - layer_state.size_vmin) / (layer_state.size_vmax - layer_state.size_vmin)
+                    marker['sizemin'] = 1
+                    marker['size'][np.isnan(marker['size'])] = 0
+                    marker['size'][marker['size'] < 0] = 0
 
-            marker['opacity'] = layer_state.alpha
+                marker['opacity'] = layer_state.alpha
 
-            fig.add_scatter(x=x, y=y,
-                            mode='markers',
-                            marker=marker)
-
+                fig.add_scatter(x=x, y=y,
+                                mode='markers',
+                                marker=marker,
+                                name=layer_state.layer.label)
+                            
         plot(fig, filename=filename, auto_open=False)
+        

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -16,6 +16,8 @@ from plotly.offline import plot
 import plotly.graph_objs as go
 
 
+DEFAULT_FONT = 'Arial, sans-serif'
+
 @viewer_tool
 class PlotlyScatter2DStaticExport(Tool):
 
@@ -29,8 +31,7 @@ class PlotlyScatter2DStaticExport(Tool):
         filename, _ = compat.getsavefilename(
             parent=self.viewer, basedir="plot.html")
 
-        width, height = np.array(self.viewer.figure.get_size_inches()*self.viewer.figure.dpi)[
-            0], np.array(self.viewer.figure.get_size_inches()*self.viewer.figure.dpi)[1]
+        width, height = self.viewer.figure.get_size_inches()*self.viewer.figure.dpi
 
         # set the aspect ratio of the axes, the tick label size, the axis label sizes, and the axes limits
         layout = go.Layout(
@@ -40,13 +41,13 @@ class PlotlyScatter2DStaticExport(Tool):
             xaxis=dict(
                 title=self.viewer.axes.get_xlabel(),
                 titlefont=dict(
-                    family='Arial, sans-serif',
+                    family=DEFAULT_FONT,
                     size=self.viewer.axes.xaxis.get_label().get_size(),
                     color='black'
                 ),
                 showticklabels=True,
                 tickfont=dict(
-                    family='Arial, sans-serif',
+                    family=DEFAULT_FONT,
                     size=self.viewer.axes.xaxis.get_ticklabels()[
                         0].get_fontsize(),
                     color='black'),
@@ -54,13 +55,13 @@ class PlotlyScatter2DStaticExport(Tool):
             yaxis=dict(
                 title=self.viewer.axes.get_xlabel(),
                 titlefont=dict(
-                    family='Arial, sans-serif',
+                    family=DEFAULT_FONT,
                     size=self.viewer.axes.yaxis.get_label().get_size(),
                     color='black'),
                 range=[self.viewer.state.y_min, self.viewer.state.y_max],
                 showticklabels=True,
                 tickfont=dict(
-                    family='Old Standard TT, serif',
+                    family=DEFAULT_FONT,
                     size=self.viewer.axes.yaxis.get_ticklabels()[
                         0].get_fontsize(),
                     color='black'),
@@ -75,8 +76,13 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 marker = {}
 
-                x = layer_state.layer[self.viewer.state.x_att]
-                y = layer_state.layer[self.viewer.state.y_att]
+                try:
+                    x = layer_state.layer[self.viewer.state.x_att]
+                    y = layer_state.layer[self.viewer.state.y_att]
+                    
+                except:
+                    print("Cannot visualize layer {}. This layer depends on attributes that cannot be derived for the underlying dataset.".format(layer_state.layer.label))
+                    continue 
 
                 # set all points to be the same color
                 if layer_state.cmap_mode == 'Fixed':
@@ -117,6 +123,10 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 # set the opacity
                 marker['opacity'] = layer_state.alpha
+                
+                #remove default white border around points
+                marker['line'] = dict(width = 0)
+
 
                 # add layer to axes
                 fig.add_scatter(x=x, y=y,

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize
 
 from qtpy import compat
 from glue.config import viewer_tool
@@ -10,7 +13,8 @@ from glue_plotly import PLOTLY_LOGO
 
 from plotly.offline import plot
 import plotly.graph_objs as go
-        
+
+
 @viewer_tool
 class PlotlyScatter3DStaticExport(Tool):
 
@@ -21,104 +25,127 @@ class PlotlyScatter3DStaticExport(Tool):
 
     def activate(self):
 
-        filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
-        
-        if self.viewer.state.native_aspect==True:
-            width=self.viewer.state.x_max-self.viewer.state.x_min
-            height=self.viewer.state.y_max-self.viewer.state.y_min
-            depth=self.viewer.state.z_max-self.viewer.state.z_min
-            
+        filename, _ = compat.getsavefilename(
+            parent=self.viewer, basedir="plot.html")
+
+        # when vispy viewer is in "native aspect ratio" mode, scale axes size by data
+        if self.viewer.state.native_aspect == True:
+            width = self.viewer.state.x_max-self.viewer.state.x_min
+            height = self.viewer.state.y_max-self.viewer.state.y_min
+            depth = self.viewer.state.z_max-self.viewer.state.z_min
+
+        # otherwise, set all axes to be equal size
         else:
-            width=1200
-            height=1200
-            depth=1200
-        
+            width = 1200  # this 1200 size is arbitrary, could change to any width; just need to scale rest accordingly
+            height = 1200
+            depth = 1200
+
+        # set the aspect ratio of the axes, the tick label size, the axis label sizes, and the axes limits
         layout = go.Layout(
-            margin=dict(r=50, l=50, b=50, t=50),  
+            margin=dict(r=50, l=50, b=50, t=50),
             width=1200,
             scene=dict(
-            xaxis=dict(
-                title=self.viewer.state.x_att.label,
-                titlefont=dict(
-                    family='Arial, sans-serif',
-                    size=20,
-                    color='black'
+                xaxis=dict(
+                    title=self.viewer.state.x_att.label,
+                    titlefont=dict(
+                        family='Arial, sans-serif',
+                        size=20,
+                        color='black'
+                    ),
+                    showticklabels=True,
+                    tickfont=dict(
+                        family='Arial, sans-serif',
+                        size=12,
+                        color='black'),
+                    range=[self.viewer.state.x_min, self.viewer.state.x_max]),
+                yaxis=dict(
+                    title=self.viewer.state.y_att.label,
+                    titlefont=dict(
+                        family='Arial, sans-serif',
+                        size=20,
+                        color='black'),
+                    range=[self.viewer.state.y_min, self.viewer.state.y_max],
+                    showticklabels=True,
+                    tickfont=dict(
+                        family='Old Standard TT, serif',
+                        size=12,
+                        color='black'),
                 ),
-                showticklabels=True,
-                tickfont=dict(
-                    family='Arial, sans-serif',
-                    size=12,
-                    color='black'),
-                range=[self.viewer.state.x_min,self.viewer.state.x_max]),
-            yaxis=dict(
-                title=self.viewer.state.y_att.label,
-                titlefont=dict(
-                    family='Arial, sans-serif',
-                    size=20,
-                    color='black'),
-                range=[self.viewer.state.y_min,self.viewer.state.y_max],
-                showticklabels=True,
-                tickfont=dict(
-                    family='Old Standard TT, serif',
-                    size=12,
-                    color='black'),
-            ),
-            zaxis=dict(
-                title=self.viewer.state.z_att.label,
-                titlefont=dict(
-                    family='Arial, sans-serif',
-                    size=20,
-                    color='black'),
-                range=[self.viewer.state.z_min,self.viewer.state.z_max],
-                showticklabels=True,
-                tickfont=dict(
-                    family='Old Standard TT, serif',
-                    size=12,
-                    color='black'),
-            ),
-            aspectratio = dict(x=1*self.viewer.state.x_stretch, y=height/width*self.viewer.state.y_stretch, z=depth/width*self.viewer.state.z_stretch),
-            aspectmode = 'manual',),
+                zaxis=dict(
+                    title=self.viewer.state.z_att.label,
+                    titlefont=dict(
+                        family='Arial, sans-serif',
+                        size=20,
+                        color='black'),
+                    range=[self.viewer.state.z_min, self.viewer.state.z_max],
+                    showticklabels=True,
+                    tickfont=dict(
+                        family='Old Standard TT, serif',
+                        size=12,
+                        color='black'),
+                ),
+                aspectratio=dict(x=1*self.viewer.state.x_stretch, y=height/width *
+                                 self.viewer.state.y_stretch, z=depth/width*self.viewer.state.z_stretch),
+                aspectmode='manual',),
         )
 
         fig = go.Figure(layout=layout)
 
-        #only show if visible in viewer
+        # only show if visible in viewer
         for layer_state in self.viewer.state.layers:
-        
-                if layer_state.visible==True:
 
-                    marker = {}
+            if layer_state.visible == True:
 
-                    x = layer_state.layer[self.viewer.state.x_att]
-                    y = layer_state.layer[self.viewer.state.y_att]
-                    z = layer_state.layer[self.viewer.state.z_att]
+                marker = {}
 
-                    if layer_state.color_mode == 'Fixed':
-                        if layer_state.color!='0.35':
-                            marker['color'] = layer_state.color
-                        else:
-                            marker['color'] =   'gray'
+                x = layer_state.layer[self.viewer.state.x_att]
+                y = layer_state.layer[self.viewer.state.y_att]
+                z = layer_state.layer[self.viewer.state.z_att]
+
+                # set all points to be the same color
+                if layer_state.color_mode == 'Fixed':
+                    if layer_state.color != '0.35':
+                        marker['color'] = layer_state.color
                     else:
-                        marker['color'] = layer_state.layer[layer_state.cmap_attribute].copy()
-                        marker['cmin'] = layer_state.cmap_vmin
-                        marker['cmax'] = layer_state.cmap_vmin
-                        marker['colorscale'] = layer_state.cmap_attribute.name.upper()
-                        marker['color'][np.isnan(marker['color'])] = -np.inf
+                        marker['color'] = 'gray'
 
-
-                    if layer_state.size_mode == 'Fixed':
-                        marker['size'] = layer_state.size
+                # color by some attribute
+                else:
+                    if layer_state.cmap_vmin > layer_state.cmap_vmax:
+                        cmap = layer_state.cmap.reversed()
+                        norm = Normalize(
+                            vmin=layer_state.cmap_vmax, vmax=layer_state.cmap_vmin)
                     else:
-                        marker['size'] = 20 * (layer_state.layer[layer_state.size_attribute] - layer_state.size_vmin) / (layer_state.size_vmax - layer_state.size_vmin)
-                        marker['sizemin'] = 1
-                        marker['size'][np.isnan(marker['size'])] = 0
-                        marker['size'][marker['size'] < 0] = 0
+                        cmap = layer_state.cmap
+                        norm = Normalize(
+                            vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
 
-                    marker['opacity'] = layer_state.alpha
+                    # most matplotlib colormaps aren't recognized by plotly, so we convert manually to a hex code
+                    rgba_list = [cmap(
+                        norm(point)) for point in layer_state.layer[layer_state.cmap_attribute].copy()]
+                    rgb_str = [r'{}'.format(colors.rgb2hex(
+                        (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
+                    marker['color'] = rgb_str
 
-                    fig.add_scatter3d(x=x, y=y, z=z,
-                                    mode='markers',
-                                    marker=marker,
-                                    name=layer_state.layer.label)
-                            
+                # set all points to be the same size, with some arbitrary scaling
+                if layer_state.size_mode == 'Fixed':
+                    marker['size'] = layer_state.size
+
+                # scale size of points by some attribute
+                else:
+                    marker['size'] = 25 * (layer_state.layer[layer_state.size_attribute] -
+                                           layer_state.size_vmin) / (layer_state.size_vmax - layer_state.size_vmin)
+                    marker['sizemin'] = 1
+                    marker['size'][np.isnan(marker['size'])] = 0
+                    marker['size'][marker['size'] < 0] = 0
+
+                # set the opacity
+                marker['opacity'] = layer_state.alpha
+
+                # add layer to axes
+                fig.add_scatter3d(x=x, y=y, z=z,
+                                  mode='markers',
+                                  marker=marker,
+                                  name=layer_state.layer.label)
+
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -15,6 +15,9 @@ from plotly.offline import plot
 import plotly.graph_objs as go
 
 
+DEFAULT_FONT = 'Arial, sans-serif'
+
+
 @viewer_tool
 class PlotlyScatter3DStaticExport(Tool):
 
@@ -48,39 +51,39 @@ class PlotlyScatter3DStaticExport(Tool):
                 xaxis=dict(
                     title=self.viewer.state.x_att.label,
                     titlefont=dict(
-                        family='Arial, sans-serif',
+                        family=DEFAULT_FONT,
                         size=20,
                         color='black'
                     ),
                     showticklabels=True,
                     tickfont=dict(
-                        family='Arial, sans-serif',
+                        family=DEFAULT_FONT,
                         size=12,
                         color='black'),
                     range=[self.viewer.state.x_min, self.viewer.state.x_max]),
                 yaxis=dict(
                     title=self.viewer.state.y_att.label,
                     titlefont=dict(
-                        family='Arial, sans-serif',
+                        family=DEFAULT_FONT,
                         size=20,
                         color='black'),
                     range=[self.viewer.state.y_min, self.viewer.state.y_max],
                     showticklabels=True,
                     tickfont=dict(
-                        family='Old Standard TT, serif',
+                        family=DEFAULT_FONT,
                         size=12,
                         color='black'),
                 ),
                 zaxis=dict(
                     title=self.viewer.state.z_att.label,
                     titlefont=dict(
-                        family='Arial, sans-serif',
+                        family=DEFAULT_FONT,
                         size=20,
                         color='black'),
                     range=[self.viewer.state.z_min, self.viewer.state.z_max],
                     showticklabels=True,
                     tickfont=dict(
-                        family='Old Standard TT, serif',
+                        family=DEFAULT_FONT,
                         size=12,
                         color='black'),
                 ),
@@ -98,9 +101,14 @@ class PlotlyScatter3DStaticExport(Tool):
 
                 marker = {}
 
-                x = layer_state.layer[self.viewer.state.x_att]
-                y = layer_state.layer[self.viewer.state.y_att]
-                z = layer_state.layer[self.viewer.state.z_att]
+                try:
+                    x = layer_state.layer[self.viewer.state.x_att]
+                    y = layer_state.layer[self.viewer.state.y_att]
+                    z = layer_state.layer[self.viewer.state.z_att]
+                    
+                except:
+                    print("Cannot visualize layer {}. This layer depends on attributes that cannot be derived for the underlying dataset.".format(layer_state.layer.label))
+                    continue 
 
                 # set all points to be the same color
                 if layer_state.color_mode == 'Fixed':
@@ -141,6 +149,8 @@ class PlotlyScatter3DStaticExport(Tool):
 
                 # set the opacity
                 marker['opacity'] = layer_state.alpha
+                marker['line'] = dict(width = 0)
+
 
                 # add layer to axes
                 fig.add_scatter3d(x=x, y=y, z=z,
@@ -149,3 +159,5 @@ class PlotlyScatter3DStaticExport(Tool):
                                   name=layer_state.layer.label)
 
         plot(fig, filename=filename, auto_open=False)
+        
+

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from qtpy import compat
+from glue.config import viewer_tool
+from glue.viewers.common.tool import Tool
+
+from glue_plotly import PLOTLY_LOGO
+
+from plotly.offline import plot
+import plotly.graph_objs as go
+        
+@viewer_tool
+class PlotlyScatter3DStaticExport(Tool):
+
+    icon = PLOTLY_LOGO
+    tool_id = 'save:plotly3d'
+    action_text = 'Save Plotly HTML page'
+    tool_tip = 'Save Plotly HTML page'
+
+    def activate(self):
+
+        filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+        
+        if self.viewer.state.native_aspect==True:
+            width=self.viewer.state.x_max-self.viewer.state.x_min
+            height=self.viewer.state.y_max-self.viewer.state.y_min
+            depth=self.viewer.state.z_max-self.viewer.state.z_min
+            
+        else:
+            width=1200
+            height=1200
+            depth=1200
+        
+        layout = go.Layout(
+            margin=dict(r=50, l=50, b=50, t=50),  
+            width=1200,
+            scene=dict(
+            xaxis=dict(
+                title=self.viewer.state.x_att.label,
+                titlefont=dict(
+                    family='Arial, sans-serif',
+                    size=20,
+                    color='black'
+                ),
+                showticklabels=True,
+                tickfont=dict(
+                    family='Arial, sans-serif',
+                    size=12,
+                    color='black'),
+                range=[self.viewer.state.x_min,self.viewer.state.x_max]),
+            yaxis=dict(
+                title=self.viewer.state.y_att.label,
+                titlefont=dict(
+                    family='Arial, sans-serif',
+                    size=20,
+                    color='black'),
+                range=[self.viewer.state.y_min,self.viewer.state.y_max],
+                showticklabels=True,
+                tickfont=dict(
+                    family='Old Standard TT, serif',
+                    size=12,
+                    color='black'),
+            ),
+            zaxis=dict(
+                title=self.viewer.state.z_att.label,
+                titlefont=dict(
+                    family='Arial, sans-serif',
+                    size=20,
+                    color='black'),
+                range=[self.viewer.state.z_min,self.viewer.state.z_max],
+                showticklabels=True,
+                tickfont=dict(
+                    family='Old Standard TT, serif',
+                    size=12,
+                    color='black'),
+            ),
+            aspectratio = dict(x=1*self.viewer.state.x_stretch, y=height/width*self.viewer.state.y_stretch, z=depth/width*self.viewer.state.z_stretch),
+            aspectmode = 'manual',),
+        )
+
+        fig = go.Figure(layout=layout)
+
+        #only show if visible in viewer
+        for layer_state in self.viewer.state.layers:
+        
+                if layer_state.visible==True:
+
+                    marker = {}
+
+                    x = layer_state.layer[self.viewer.state.x_att]
+                    y = layer_state.layer[self.viewer.state.y_att]
+                    z = layer_state.layer[self.viewer.state.z_att]
+
+                    if layer_state.color_mode == 'Fixed':
+                        if layer_state.color!='0.35':
+                            marker['color'] = layer_state.color
+                        else:
+                            marker['color'] =   'gray'
+                    else:
+                        marker['color'] = layer_state.layer[layer_state.cmap_attribute].copy()
+                        marker['cmin'] = layer_state.cmap_vmin
+                        marker['cmax'] = layer_state.cmap_vmin
+                        marker['colorscale'] = layer_state.cmap_attribute.name.upper()
+                        marker['color'][np.isnan(marker['color'])] = -np.inf
+
+
+                    if layer_state.size_mode == 'Fixed':
+                        marker['size'] = layer_state.size
+                    else:
+                        marker['size'] = 20 * (layer_state.layer[layer_state.size_attribute] - layer_state.size_vmin) / (layer_state.size_vmax - layer_state.size_vmin)
+                        marker['sizemin'] = 1
+                        marker['size'][np.isnan(marker['size'])] = 0
+                        marker['size'][marker['size'] < 0] = 0
+
+                    marker['opacity'] = layer_state.alpha
+
+                    fig.add_scatter3d(x=x, y=y, z=z,
+                                    mode='markers',
+                                    marker=marker,
+                                    name=layer_state.layer.label)
+                            
+        plot(fig, filename=filename, auto_open=False)


### PR DESCRIPTION
This pull request does two things:

1) It adds additional functionality for the 2D plot.ly html exporter:
- Correctly colors points by some attribute according to some colormap
- Preserves figure size
- Preserves axis label name
- Preserves axis label size
- Preserves tick size

2) Adds in a 3D html plot.ly exporter, which does all of the above, plus recognizes and scales by the axis stretching and "Native Aspect Ratio On/Off" choice provided by the user. 
