### PR TITLE
Support for polar scatterplots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.4 (unreleased)
+----------------
+
+- Add support for 2d polar scatter plots. [#12]
+
 0.3 (2021-10-19)
 ----------------
 

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -74,10 +74,15 @@ class PlotlyScatter2DStaticExport(Tool):
 
         if polar:
             angle_unit = 'degrees' if degrees else 'radians'
+            theta_prefix = ''
+            if self.viewer.state.x_axislabel:
+                theta_prefix = '{0}='.format(self.viewer.state.x_axislabel)
             angular_axis = dict(
                 type='linear',
                 thetaunit=angle_unit,
                 showticklabels=True,
+                showtickprefix='first',
+                tickprefix=theta_prefix,
                 tickfont=dict(
                     family=DEFAULT_FONT,
                     size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
@@ -88,6 +93,12 @@ class PlotlyScatter2DStaticExport(Tool):
                 type='linear',
                 range=[self.viewer.state.y_min, self.viewer.state.y_max],
                 showticklabels=True,
+                tickmode='array',
+                tickvals=self.viewer.axes.yaxis.get_majorticklocs(),
+                ticktext=['<i>{0}</i>'.format(t.get_text()) for t in self.viewer.axes.yaxis.get_majorticklabels()],
+                angle=22.5,
+                tickangle=22.5,
+                showline=False,
                 tickfont=dict(
                     family=DEFAULT_FONT,
                     size=1.5*self.viewer.axes.yaxis.get_ticklabels()[

--- a/glue_plotly/html_exporters/tests/test_scatter2d.py
+++ b/glue_plotly/html_exporters/tests/test_scatter2d.py
@@ -38,10 +38,27 @@ class TestScatter2D:
         self.app.close()
         self.app = None
 
-    def test_default(self, tmpdir):
-        output_file = tmpdir.join('test.html').strpath
+    def export_figure(self, tmpdir, output_filename):
+        output_path = tmpdir.join(output_filename).strpath
         with patch('qtpy.compat.getsavefilename') as fd:
-            fd.return_value = output_file, 'html'
+            fd.return_value = output_path, 'html'
             with patch.object(SaveHoverDialog, 'exec_', auto_accept()):
                 self.tool.activate()
-        assert os.path.exists(output_file)
+        return output_path
+
+    def test_default(self, tmpdir):
+        self.viewer.state.plot_mode = 'rectilinear'
+        output_path = self.export_figure(tmpdir, 'test_rectilinear.html')
+        assert os.path.exists(output_path)
+
+    def test_polar_radians(self, tmpdir):
+        self.viewer.state.plot_mode = 'polar'
+        self.viewer.state.angle_unit = 'radians'
+        output_path = self.export_figure(tmpdir, 'test_polar_radians.html')
+        assert os.path.exists(output_path)
+
+    def test_polar_degrees(self, tmpdir):
+        self.viewer.state.plot_mode = 'polar'
+        self.viewer.state.angle_unit = 'degrees'
+        output_path = self.export_figure(tmpdir, 'test_polar_degrees.html')
+        assert os.path.exists(output_path)


### PR DESCRIPTION
This PR adds support for exporting polar scatterplots. This is accomplished by using the `plotly.graph_objs.layout.Polar` layout.

The tick marks for the radial axis are grabbed directly from the scatter viewer and italicized via HTML tags (as best as I can see, there's no option to directly italicize the font). For the theta axis, the formatting used to create the pi symbol in the ticks in matplotlib doesn't work in plotly, so rather than try some sort of text replacement hack, this PR just lets plotly use its own tick marks and adds a suffix for the theta=0 marker.

Some examples of the output are [here](https://drive.google.com/drive/folders/1exXR0wGmgSSfHv4u-Hnyt_1Fb3XZagMO?usp=sharing). Most of these are using the W5 dataset, but the output of the polar plot used in the airplane video is in there as well (that file takes a few seconds to load).
