### PR TITLE
Set camera projection based on viewer state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4 (unreleased)
 ----------------
 
+- Set exported camera projection based on glue viewer state. [#13]
+
 - Add support for 2d polar scatter plots. [#12]
 
 0.3 (2021-10-19)

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -72,6 +72,9 @@ class PlotlyScatter3DStaticExport(Tool):
             height = 1200
             depth = 1200
 
+        # check which projection we want to use
+        projection_type = "perspective" if self.viewer.state.perspective_view else "orthographic"
+
         # set the aspect ratio of the axes, the tick label size, the axis label sizes, and the axes limits
         layout = go.Layout(
             margin=dict(r=50, l=50, b=50, t=50),  # noqa
@@ -124,6 +127,11 @@ class PlotlyScatter3DStaticExport(Tool):
                         family=DEFAULT_FONT,
                         size=12,
                         color='black'),
+                ),
+                camera=dict(
+                    projection=dict(
+                        type=projection_type
+                    )
                 ),
                 aspectratio=dict(x=1*self.viewer.state.x_stretch, y=height/width *
                                  self.viewer.state.y_stretch, z=depth/width*self.viewer.state.z_stretch),


### PR DESCRIPTION
This PR sets the projection of the camera used in the exported file based on the `perspective_view` property of the glue layer state. If `perspective_view` is true, `"perspective"` is used, while `"orthographic"` is used if it's false. Note that these are the only two options supported in plotly (relevant documentation is [here](https://plotly.com/python/reference/layout/scene/#layout-scene-camera-projection-type)).

I'm happy to add tests using both options if we think it's necessary.