### PR TITLE
Allow exporting of plots with a categorical size attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4 (unreleased)
 ----------------
 
+- Allow exporting of plots with a categorical size attribute. [#14]
+
 - Add support for 2d polar scatter plots. [#12]
 
 0.3 (2021-10-19)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -8,6 +8,7 @@ from qtpy import compat
 from glue.config import viewer_tool
 
 from glue.core import DataCollection, Data
+from glue.utils import ensure_numerical
 
 from .. import save_hover
 
@@ -190,7 +191,8 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 # scale size of points by some attribute
                 else:
-                    marker['size'] = 25 * (layer_state.layer[layer_state.size_att] - layer_state.size_vmin) / (
+                    s = ensure_numerical(layer_state.layer[layer_state.size_att].ravel())
+                    marker['size'] = 25 * (s - layer_state.size_vmin) / (
                         layer_state.size_vmax - layer_state.size_vmin)
                     marker['sizemin'] = 1
                     marker['size'][np.isnan(marker['size'])] = 0

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -8,6 +8,7 @@ from qtpy import compat
 from glue.config import viewer_tool
 
 from glue.core import DataCollection, Data
+from glue.utils import ensure_numerical
 
 try:
     from glue.viewers.common.qt.tool import Tool
@@ -175,8 +176,9 @@ class PlotlyScatter3DStaticExport(Tool):
 
                 # scale size of points by some attribute
                 else:
-                    marker['size'] = 25 * (layer_state.layer[layer_state.size_attribute] -
-                                           layer_state.size_vmin) / (layer_state.size_vmax - layer_state.size_vmin)
+                    s = ensure_numerical(layer_state.layer[layer_state.size_attribute].ravel())
+                    marker['size'] = 25 * (s - layer_state.size_vmin) / (
+                        layer_state.size_vmax - layer_state.size_vmin)
                     marker['sizemin'] = 1
                     marker['size'][np.isnan(marker['size'])] = 0
                     marker['size'][marker['size'] < 0] = 0


### PR DESCRIPTION
While working on adding the perspective option, I noticed that 3d plots will not export if the size attribute is categorical, despite the fact that this is allowed in glue. This is due to the subtraction in the numerator [here](https://github.com/glue-viz/glue-plotly/blob/main/glue_plotly/html_exporters/scatter3d.py#L178) being undefined (since the first array is non-numeric).

This PR fixes this issue by using `ensure_numerical` on the categorical data. This is the same technique used in the [2d scatter layer artist](https://github.com/glue-viz/glue/blob/main/glue/viewers/scatter/layer_artist.py#L413), as well as in the 3d scatter layer artist (it doesn't make a call to `ensure_numerical` there, but it performs the same operation [here](https://github.com/glue-viz/glue-vispy-viewers/blob/master/glue_vispy_viewers/scatter/layer_artist.py#L134)).

This shouldn't be an issue for the 2d scatter export (the 2d scatter viewer restricts the possible size attributes to numerical ones, which the 3d viewer doesn't), but I've added the same operation there for good measure.
