### PR TITLE
Improvements to 3D scatter exporter

### DIFF
--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -236,26 +236,40 @@ class PlotlyScatter3DStaticExport(Tool):
                     anchor = anchor_dict[layer_state.vector_origin]
                     name = layer_state.layer.label + " cones"
                     cones = []
+
+                    viewer_state = self.viewer.state
+                    indices = (x >= viewer_state.x_min) & (x <= viewer_state.x_max) & \
+                              (y >= viewer_state.y_min) & (y <= viewer_state.y_max) & \
+                              (z >= viewer_state.z_min) & (z <= viewer_state.z_max)
+                    x = x[indices]
+                    y = y[indices]
+                    z = z[indices]
+                    vx = vx[indices]
+                    vy = vy[indices]
+                    vz = vz[indices]
+
                     if layer_state.color_mode == 'Fixed':
                         # get the singular color in rgb format
                         rgb_color = [int(c * 256) for c in colors.to_rgb(marker["color"])]
                         c = 'rgb{}'.format(tuple(rgb_color))
-                        cone_info = dict(x=x, y=y, z=z, u=vx, v=vy, w=vz,
-                                         name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
-                                         hoverinfo='skip', showscale=False,
-                                         showlegend=True, sizeref=layer_state.vector_scaling)
-                        cones.append(cone_info)
+                        colorscale = [[0, c], [1, c]]
+
+                        for i in range(len(x)):
+                            cone_info = dict(x=[x[i]], y=[y[i]], z=[z[i]],
+                                             u=[vx[i]], v=[vy[i]], w=[vz[i]],
+                                             name=name, anchor=anchor, colorscale=colorscale,
+                                             hoverinfo='skip', showscale=False, legendgroup=name,
+                                             sizemode="scaled", showlegend=not i, sizeref=layer_state.vector_scaling)
+                            cones.append(cone_info)
                     else:
-                        rgb_colors = list((int(rgba[0] * 256), int(rgba[1] * 256), int(rgba[2] * 256))
-                                          for rgba in rgba_list)
+                        rgb_colors = [(int(t * 256) for t in rgba[:3]) for rgba in rgba_list]
                         for i in range(len(marker['color'])):
                             c = 'rgb{}'.format(rgb_colors[i])
                             cone_info = dict(x=[x[i]], y=[y[i]], z=[z[i]],
                                              u=[vx[i]], v=[vy[i]], w=[vz[i]],
-                                             anchor=anchor, colorscale=[[0, c], [1, c]],
-                                             name=name, showlegend=i is 0,
+                                             name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
                                              hoverinfo='skip', showscale=False, legendgroup=name,
-                                             sizeref=layer_state.vector_scaling)
+                                             sizemode="scaled", showlegend=not i, sizeref=layer_state.vector_scaling)
                             cones.append(cone_info)
                     fig.update_layout(layout)
 

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -15,7 +15,6 @@ try:
 except ImportError:
     from glue.viewers.common.tool import Tool
 
-
 from glue_plotly import PLOTLY_LOGO
 from .. import save_hover
 
@@ -23,13 +22,11 @@ from plotly.offline import plot
 import plotly.graph_objs as go
 from glue.core.qt.dialogs import warn
 
-
 DEFAULT_FONT = 'Arial, sans-serif'
 
 
 @viewer_tool
 class PlotlyScatter3DStaticExport(Tool):
-
     icon = PLOTLY_LOGO
     tool_id = 'save:plotly3d'
     action_text = 'Save Plotly HTML page'
@@ -57,8 +54,10 @@ class PlotlyScatter3DStaticExport(Tool):
                 checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(bool)
 
         dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-        proceed = warn('Scatter 3d plotly may look different', 'Plotly and Matlotlib graphics differ and your graph may look different when exported. Do you want to proceed?',
-                    default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
+        proceed = warn('Scatter 3d plotly may look different',
+                       'Plotly and Matlotlib graphics differ and your graph may look different when exported. Do you '
+                       'want to proceed?',
+                       default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
         if not proceed:
             return
         dialog.exec_()
@@ -69,9 +68,9 @@ class PlotlyScatter3DStaticExport(Tool):
 
         # when vispy viewer is in "native aspect ratio" mode, scale axes size by data
         if self.viewer.state.native_aspect:
-            width = self.viewer.state.x_max-self.viewer.state.x_min
-            height = self.viewer.state.y_max-self.viewer.state.y_min
-            depth = self.viewer.state.z_max-self.viewer.state.z_min
+            width = self.viewer.state.x_max - self.viewer.state.x_min
+            height = self.viewer.state.y_max - self.viewer.state.y_min
+            depth = self.viewer.state.z_max - self.viewer.state.z_min
 
         # otherwise, set all axes to be equal size
         else:
@@ -159,9 +158,10 @@ class PlotlyScatter3DStaticExport(Tool):
                         type=projection_type
                     )
                 ),
-                aspectratio=dict(x=1*self.viewer.state.x_stretch, y=height/width *
-                                 self.viewer.state.y_stretch, z=depth/width*self.viewer.state.z_stretch),
-                aspectmode='manual',),
+                aspectratio=dict(x=1 * self.viewer.state.x_stretch,
+                                 y=height / width * self.viewer.state.y_stretch,
+                                 z=depth / width * self.viewer.state.z_stretch),
+                                 aspectmode='manual'),
         )
 
         fig = go.Figure(layout=layout)
@@ -211,7 +211,7 @@ class PlotlyScatter3DStaticExport(Tool):
                 else:
                     s = ensure_numerical(layer_state.layer[layer_state.size_attribute].ravel())
                     s = ((s - layer_state.size_vmin) /
-                                 (layer_state.size_vmax - layer_state.size_vmin))
+                         (layer_state.size_vmax - layer_state.size_vmin))
                     # The following ensures that the sizes are in the
                     # range 3 to 30 before the final size scaling.
                     np.clip(s, 0, 1, out=s)
@@ -225,35 +225,36 @@ class PlotlyScatter3DStaticExport(Tool):
                 marker['line'] = dict(width=0)
 
                 if layer_state.vector_visible:
-                    proceed = warn('Arrows may look different', 'Plotly and Matlotlib vector graphics differ and your graph may look different when exported. Do you want to proceed?',
-                    default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
+                    proceed = warn('Arrows may look different',
+                                   'Plotly and Matlotlib vector graphics differ and your graph may look different '
+                                   'when exported. Do you want to proceed?',
+                                   default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
                     if not proceed:
                         return
                     vx = layer_state.layer[layer_state.vx_attribute]
                     vy = layer_state.layer[layer_state.vy_attribute]
                     vz = layer_state.layer[layer_state.vz_attribute]
                     # convert anchor names from glue values to plotly values
-                    anchor_dict = {'middle':'center', 'tip':'tip', 'tail':
-                    'tail'}
+                    anchor_dict = {'middle': 'center', 'tip': 'tip', 'tail': 'tail'}
                     anchor = anchor_dict[layer_state.vector_origin]
                     if layer_state.color_mode == 'Fixed':
                         # get the singular color in rgb format
                         c = 'rgb{}'.format(tuple(int(
-                            marker['color'][i:i+2], 16) for i in (1, 3, 5)))
+                            marker['color'][i:i + 2], 16) for i in (1, 3, 5)))
                         fig.add_cone(x=x, y=y, z=z, u=vx, v=vy, w=vz,
-                                    anchor=anchor, colorscale=[[0, c], [1, c]],
-                                    hoverinfo='skip', showscale=False,
-                                    showlegend=False)
+                                     anchor=anchor, colorscale=[[0, c], [1, c]],
+                                     hoverinfo='skip', showscale=False,
+                                     showlegend=False)
                     else:
-                        rgb_colors = list((int(rgba[0]*256), int(rgba[1]*256), int(rgba[2]*256)) 
-                                             for rgba in rgba_list)
+                        rgb_colors = list((int(rgba[0] * 256), int(rgba[1] * 256), int(rgba[2] * 256))
+                                          for rgba in rgba_list)
                         for i in range(len(marker['color'])):
-                            fig.add_cone(x=[x[i]], y=[y[i]], z=[z[i]], 
-                                u=[vx[i]], v=[vy[i]], w=[vz[i]], anchor=anchor,
-                                colorscale=[[0, 'rgb{}'.format(rgb_colors[i])], 
-                                [1, 'rgb{}'.format(rgb_colors[i])]],
-                                hoverinfo='skip',
-                                showscale=False, showlegend=False, sizeref=0.3)
+                            fig.add_cone(x=[x[i]], y=[y[i]], z=[z[i]],
+                                         u=[vx[i]], v=[vy[i]], w=[vz[i]], anchor=anchor,
+                                         colorscale=[[0, 'rgb{}'.format(rgb_colors[i])],
+                                                     [1, 'rgb{}'.format(rgb_colors[i])]],
+                                         hoverinfo='skip',
+                                         showscale=False, showlegend=False, sizeref=0.3)
                     fig.update_layout(layout)
 
                 # add error bars
@@ -263,15 +264,14 @@ class PlotlyScatter3DStaticExport(Tool):
                     xerr['array'] = np.absolute(ensure_numerical(
                         layer_state.layer[layer_state.xerr_attribute].ravel()))
                     xerr['visible'] = True
-                    
-                
+
                 yerr = {}
                 if layer_state.yerr_visible:
                     yerr['type'] = 'data'
                     yerr['array'] = np.absolute(ensure_numerical(
                         layer_state.layer[layer_state.yerr_attribute].ravel()))
                     yerr['visible'] = True
-                
+
                 zerr = {}
                 if layer_state.zerr_visible:
                     zerr['type'] = 'data'

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -5,7 +5,7 @@ import matplotlib.colors as colors
 from matplotlib.colors import Normalize
 
 from qtpy import compat
-from glue.config import viewer_tool, settings, colormaps
+from glue.config import viewer_tool, settings
 
 from glue.core import DataCollection, Data
 from glue.utils import ensure_numerical
@@ -163,7 +163,8 @@ class PlotlyScatter3DStaticExport(Tool):
                 aspectratio=dict(x=1 * self.viewer.state.x_stretch,
                                  y=height / width * self.viewer.state.y_stretch,
                                  z=depth / width * self.viewer.state.z_stretch),
-                                 aspectmode='manual'),
+                aspectmode='manual'
+            )
         )
 
         fig = go.Figure(layout=layout)

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -23,6 +23,7 @@ import plotly.graph_objs as go
 from glue.core.qt.dialogs import warn
 
 DEFAULT_FONT = 'Arial, sans-serif'
+settings.add('SHOW_WARN_PLOTLY_3D_GRAPHICS_DIFFERENT', True)
 
 
 @viewer_tool
@@ -57,9 +58,10 @@ class PlotlyScatter3DStaticExport(Tool):
         proceed = warn('Scatter 3d plotly may look different',
                        'Plotly and Matlotlib graphics differ and your graph may look different when exported. Do you '
                        'want to proceed?',
-                       default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
+                       default='Cancel', setting='SHOW_WARN_PLOTLY_3D_GRAPHICS_DIFFERENT')
         if not proceed:
             return
+
         dialog.exec_()
 
         # query filename
@@ -225,12 +227,6 @@ class PlotlyScatter3DStaticExport(Tool):
                 marker['line'] = dict(width=0)
 
                 if layer_state.vector_visible:
-                    proceed = warn('Arrows may look different',
-                                   'Plotly and Matlotlib vector graphics differ and your graph may look different '
-                                   'when exported. Do you want to proceed?',
-                                   default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
-                    if not proceed:
-                        return
                     vx = layer_state.layer[layer_state.vx_attribute]
                     vy = layer_state.layer[layer_state.vy_attribute]
                     vz = layer_state.layer[layer_state.vz_attribute]

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -235,6 +235,7 @@ class PlotlyScatter3DStaticExport(Tool):
                     anchor_dict = {'middle': 'center', 'tip': 'tip', 'tail': 'tail'}
                     anchor = anchor_dict[layer_state.vector_origin]
                     name = layer_state.layer.label + " cones"
+                    cones = []
                     if layer_state.color_mode == 'Fixed':
                         # get the singular color in rgb format
                         rgb_color = [int(c * 256) for c in colors.to_rgb(marker["color"])]
@@ -243,6 +244,7 @@ class PlotlyScatter3DStaticExport(Tool):
                                          name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
                                          hoverinfo='skip', showscale=False,
                                          showlegend=True, sizeref=layer_state.vector_scaling)
+                        cones.append(cone_info)
                     else:
                         rgb_colors = list((int(rgba[0] * 256), int(rgba[1] * 256), int(rgba[2] * 256))
                                           for rgba in rgba_list)
@@ -250,9 +252,11 @@ class PlotlyScatter3DStaticExport(Tool):
                             c = 'rgb{}'.format(rgb_colors[i])
                             cone_info = dict(x=[x[i]], y=[y[i]], z=[z[i]],
                                              u=[vx[i]], v=[vy[i]], w=[vz[i]],
-                                             name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
-                                             hoverinfo='skip', showscale=False,
-                                             showlegend=True, sizeref=layer_state.vector_scaling)
+                                             anchor=anchor, colorscale=[[0, c], [1, c]],
+                                             name=name, showlegend=i is 0,
+                                             hoverinfo='skip', showscale=False, legendgroup=name,
+                                             sizeref=layer_state.vector_scaling)
+                            cones.append(cone_info)
                     fig.update_layout(layout)
 
                 # add error bars
@@ -305,6 +309,8 @@ class PlotlyScatter3DStaticExport(Tool):
 
                 # add the cones here so that they show up after the data in the legend
                 if layer_state.vector_visible:
-                    fig.add_cone(**cone_info)
+                    for cone in cones:
+                        fig.add_cone(**cone)
 
+        print(fig)
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -234,25 +234,25 @@ class PlotlyScatter3DStaticExport(Tool):
                     # convert anchor names from glue values to plotly values
                     anchor_dict = {'middle': 'center', 'tip': 'tip', 'tail': 'tail'}
                     anchor = anchor_dict[layer_state.vector_origin]
-                    name = layer_state.layer.label + " vectors"
+                    name = layer_state.layer.label + " cones"
                     if layer_state.color_mode == 'Fixed':
                         # get the singular color in rgb format
                         rgb_color = [int(c * 256) for c in colors.to_rgb(marker["color"])]
                         c = 'rgb{}'.format(tuple(rgb_color))
-                        fig.add_cone(x=x, y=y, z=z, u=vx, v=vy, w=vz,
-                                     name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
-                                     hoverinfo='skip', showscale=False,
-                                     showlegend=True, sizeref=layer_state.vector_scaling)
+                        cone_info = dict(x=x, y=y, z=z, u=vx, v=vy, w=vz,
+                                         name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
+                                         hoverinfo='skip', showscale=False,
+                                         showlegend=True, sizeref=layer_state.vector_scaling)
                     else:
                         rgb_colors = list((int(rgba[0] * 256), int(rgba[1] * 256), int(rgba[2] * 256))
                                           for rgba in rgba_list)
                         for i in range(len(marker['color'])):
                             c = 'rgb{}'.format(rgb_colors[i])
-                            fig.add_cone(x=[x[i]], y=[y[i]], z=[z[i]],
-                                         u=[vx[i]], v=[vy[i]], w=[vz[i]],
-                                         name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
-                                         hoverinfo='skip', showscale=False,
-                                         showlegend=True, sizeref=layer_state.vector_scaling)
+                            cone_info = dict(x=[x[i]], y=[y[i]], z=[z[i]],
+                                             u=[vx[i]], v=[vy[i]], w=[vz[i]],
+                                             name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
+                                             hoverinfo='skip', showscale=False,
+                                             showlegend=True, sizeref=layer_state.vector_scaling)
                     fig.update_layout(layout)
 
                 # add error bars
@@ -302,5 +302,9 @@ class PlotlyScatter3DStaticExport(Tool):
                                   hoverinfo=hoverinfo,
                                   hovertext=hovertext,
                                   name=layer_state.layer.label)
+
+                # add the cones here so that they show up after the data in the legend
+                if layer_state.vector_visible:
+                    fig.add_cone(**cone_info)
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -233,24 +233,25 @@ class PlotlyScatter3DStaticExport(Tool):
                     # convert anchor names from glue values to plotly values
                     anchor_dict = {'middle': 'center', 'tip': 'tip', 'tail': 'tail'}
                     anchor = anchor_dict[layer_state.vector_origin]
+                    name = layer_state.layer.label + " vectors"
                     if layer_state.color_mode == 'Fixed':
                         # get the singular color in rgb format
-                        c = 'rgb{}'.format(tuple(int(
-                            marker['color'][i:i + 2], 16) for i in (1, 3, 5)))
+                        rgb_color = [int(c * 256) for c in colors.to_rgb(marker["color"])]
+                        c = 'rgb{}'.format(tuple(rgb_color))
                         fig.add_cone(x=x, y=y, z=z, u=vx, v=vy, w=vz,
-                                     anchor=anchor, colorscale=[[0, c], [1, c]],
+                                     name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
                                      hoverinfo='skip', showscale=False,
-                                     showlegend=False)
+                                     showlegend=True, sizeref=layer_state.vector_scaling)
                     else:
                         rgb_colors = list((int(rgba[0] * 256), int(rgba[1] * 256), int(rgba[2] * 256))
                                           for rgba in rgba_list)
                         for i in range(len(marker['color'])):
+                            c = 'rgb{}'.format(rgb_colors[i])
                             fig.add_cone(x=[x[i]], y=[y[i]], z=[z[i]],
-                                         u=[vx[i]], v=[vy[i]], w=[vz[i]], anchor=anchor,
-                                         colorscale=[[0, 'rgb{}'.format(rgb_colors[i])],
-                                                     [1, 'rgb{}'.format(rgb_colors[i])]],
-                                         hoverinfo='skip',
-                                         showscale=False, showlegend=False, sizeref=0.3)
+                                         u=[vx[i]], v=[vy[i]], w=[vz[i]],
+                                         name=name, anchor=anchor, colorscale=[[0, c], [1, c]],
+                                         hoverinfo='skip', showscale=False,
+                                         showlegend=True, sizeref=layer_state.vector_scaling)
                     fig.update_layout(layout)
 
                 # add error bars

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -110,7 +110,9 @@ class PlotlyScatter3DStaticExport(Tool):
                     showline=True,
                     linecolor=settings.FOREGROUND_COLOR,
                     tickcolor=settings.FOREGROUND_COLOR,
-                    range=[self.viewer.state.x_min, self.viewer.state.x_max]),
+                    range=[self.viewer.state.x_min, self.viewer.state.x_max],
+                    visible=self.viewer.state.visible_axes
+                ),
                 yaxis=dict(
                     title=self.viewer.state.y_att.label,
                     titlefont=dict(
@@ -131,7 +133,8 @@ class PlotlyScatter3DStaticExport(Tool):
                     ticks='outside',
                     showline=True,
                     linecolor=settings.FOREGROUND_COLOR,
-                    tickcolor=settings.FOREGROUND_COLOR
+                    tickcolor=settings.FOREGROUND_COLOR,
+                    visible=self.viewer.state.visible_axes
                 ),
                 zaxis=dict(
                     title=self.viewer.state.z_att.label,
@@ -153,7 +156,8 @@ class PlotlyScatter3DStaticExport(Tool):
                     ticks='outside',
                     showline=True,
                     linecolor=settings.FOREGROUND_COLOR,
-                    tickcolor=settings.FOREGROUND_COLOR
+                    tickcolor=settings.FOREGROUND_COLOR,
+                    visible=self.viewer.state.visible_axes
                 ),
                 camera=dict(
                     projection=dict(

--- a/glue_plotly/html_exporters/tests/test_scatter3d.py
+++ b/glue_plotly/html_exporters/tests/test_scatter3d.py
@@ -8,16 +8,25 @@ from mock import patch
 from glue.core import Data
 from glue.app.qt import GlueApplication
 from glue_plotly.save_hover import SaveHoverDialog
+from qtpy.QtWidgets import QMessageBox
 
 pytest.importorskip('glue_vispy_viewers')
 
 from glue_vispy_viewers.scatter.scatter_viewer import VispyScatterViewer  # noqa
 
 
-def auto_accept():
+def auto_accept_hoverdialog():
     def exec_replacement(self):
         self.select_all()
         self.accept()
+
+    return exec_replacement
+
+
+def auto_accept_messagebox():
+    def exec_replacement(self):
+        self.accept()
+
     return exec_replacement
 
 
@@ -34,7 +43,7 @@ class TestScatter3D:
                 self.tool = subtool
                 break
         else:
-            raise Exception("Could not find save:plotly2d tool in viewer")
+            raise Exception("Could not find save:plotly3d tool in viewer")
 
     def teardown_method(self, method):
         self.viewer.close(warn=False)
@@ -46,6 +55,7 @@ class TestScatter3D:
         output_file = tmpdir.join('test.html').strpath
         with patch('qtpy.compat.getsavefilename') as fd:
             fd.return_value = output_file, 'html'
-            with patch.object(SaveHoverDialog, 'exec_', auto_accept()):
+            with patch.object(SaveHoverDialog, 'exec_', auto_accept_hoverdialog()), \
+                 patch.object(QMessageBox, 'exec_', auto_accept_messagebox()):
                 self.tool.activate()
         assert os.path.exists(output_file)


### PR DESCRIPTION
This PR contains improvements to the 3D scatter viewer from @victoriaono and myself. While we had previously opened #16, I've decided to split that into multiple PRs that each deal with changes to a specific exporter, just to keep things from getting unwieldy. This PR contains the 3D scatter-specific changes from #16, as well as some additional changes.

The features added to the 3D scatter viewer are:
* Support for error bars
* Support for vectors, via Plotly's cone traces
* Support for point size scaling
* The exported Plotly file now respects glue's color settings (foreground/background)
    - This works fine, but will be easier to test out once https://github.com/glue-viz/glue-vispy-viewers/pull/372 has been merged in
* Respect whether or not a user has axes visible in glue

There are a few issues, as well as a few choices that I think are worth mentioning.
* As far as I can tell, Plotly doesn't show anything outside of the bounding box. This is different than the glue behavior, but unless I'm missing something re:Plotly functionality, I don't see what we can do about that.
* As mentioned above, we can now support vectors using Plotly's cone traces. However, there are a few issues that pop up due to differences between glue and Plotly.
    - Plotly offers a colorscale option for cones, but the colorscale is used for mapping colors to cones according to their norm. That's not really what we want, since glue gives users the option to set the colormap based on any attribute. Thus for colormapped layers, a separate cone trace is created, with a constant colorscale of the appropriate color, for each element of the data set.
    - Aside from the colorscale issues, Plotly does its own internal scaling (in addition to the `sizeref` parameter that can be passed to a Cone trace) based on "the minimum 'time' to travel across two successive x/y/z positions at the average velocity of those two successive positions" - see the description of the `sizeref` parameter [here](https://plotly.com/python-api-reference/generated/plotly.graph_objects.Figure.html?highlight=add_cone#plotly.graph_objects.Figure.add_cone). In my testing, this parameter can get really small if there are cones close together. Since we don't seem to be able to change this (see issue 3613 over in the plotly repo), I've opted to make each cone its own trace for fixed-color layers as well.
    - In both of these cases, to give the illusion to the user that we are creating one cone trace per layer, I've grouped all of the cones into one legend group, and only displayed the legend for the first item. I've opted to include the cones in the legend so that the user can turn them on/off in the exported Plotly file.
    - With the cone's center anchored to the point, the underlying data points are completely obscured, which makes seeing hover info impossible (even in the other configurations, mousing exactly to the data point can be annoying). Thus, I've attached the relevant hover info and text to each cone as well.

To warn users that the Plotly output may differ from what they see in glue, a warning message is displayed before exporting, which is attached to the (new) setting `SHOW_WARN_PLOTLY_3D_GRAPHICS_DIFFERENT`. Personally I think it's better to show one catch-all "things might be different" message rather than separate messages for each component that might differ (vectors, etc.).

I'll add some tests once we see whether or not there's more to be done with this.