### PR TITLE
Add exporter for histogram viewer

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -26,6 +26,9 @@ def setup():
         "save": ImageViewer.subtools["save"] + ['save:plotlyimage2d']
     }
 
+    from glue.viewers.histogram.qt import HistogramViewer
+    HistogramViewer.subtools['save'] = HistogramViewer.subtools['save'] + ['save:plotlyhist']
+
     try:
         from glue_vispy_viewers.scatter.scatter_viewer import VispyScatterViewer
     except ImportError:

--- a/glue_plotly/html_exporters/__init__.py
+++ b/glue_plotly/html_exporters/__init__.py
@@ -1,3 +1,4 @@
 from . import scatter2d  # noqa
 from . import scatter3d  # noqa
 from . import image # noqa
+from . import histogram  # noqa

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -49,9 +49,6 @@ class PlotlyHistogram1DExport(Tool):
             if layer_state.visible and layer.enabled:
                 checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(bool)
 
-        dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-        dialog.exec_()
-
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
 
         width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
@@ -154,6 +151,7 @@ class PlotlyHistogram1DExport(Tool):
                 hist_info = dict(
                     x=x,
                     y=y,
+                    hoverinfo='skip',
                     marker=marker,
                     name=layer_state.layer.label
                 )

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -18,14 +18,12 @@ from glue_plotly import PLOTLY_LOGO
 
 from plotly.offline import plot
 import plotly.graph_objs as go
-from glue.core.qt.dialogs import warn
 
 DEFAULT_FONT = 'Arial, sans-serif'
 
 
 @viewer_tool
 class PlotlyHistogram1DExport(Tool):
-
     icon = PLOTLY_LOGO
     tool_id = 'save:plotlyhist'
     action_text = 'Save Plotly HTML page'
@@ -52,31 +50,29 @@ class PlotlyHistogram1DExport(Tool):
                 checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(bool)
 
         dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-        proceed = warn('Histogram plotly may look different', 'Plotly and Matlotlib binning methods differ and your graph may look different when exported. Do you want to proceed?',
-                    default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
-        if not proceed:
-            return
         dialog.exec_()
 
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
 
-        width, height = self.viewer.figure.get_size_inches()*self.viewer.figure.dpi
+        width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
 
         # set the aspect ratio of the axes, the tick label size, the axis label
         # sizes, and the axes limits
         layout_config = dict(
             margin=dict(r=50, l=50, b=50, t=50),  # noqa
             width=1200,
-            height=1200*height/width,  # scale axis correctly
+            height=1200 * height / width,  # scale axis correctly
             paper_bgcolor=settings.BACKGROUND_COLOR,
-            plot_bgcolor=settings.BACKGROUND_COLOR
+            plot_bgcolor=settings.BACKGROUND_COLOR,
+            barmode="overlay",
+            bargap=0
         )
 
         x_axis = dict(
             title=self.viewer.axes.get_xlabel(),
             titlefont=dict(
                 family=DEFAULT_FONT,
-                size=2*self.viewer.axes.xaxis.get_label().get_size(),
+                size=2 * self.viewer.axes.xaxis.get_label().get_size(),
                 color=settings.FOREGROUND_COLOR
             ),
             showspikes=False,
@@ -89,7 +85,7 @@ class PlotlyHistogram1DExport(Tool):
             showticklabels=True,
             tickfont=dict(
                 family=DEFAULT_FONT,
-                size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
+                size=1.5 * self.viewer.axes.xaxis.get_ticklabels()[
                     0].get_fontsize(),
                 color=settings.FOREGROUND_COLOR),
             range=[self.viewer.state.x_min, self.viewer.state.x_max]
@@ -98,7 +94,7 @@ class PlotlyHistogram1DExport(Tool):
             title=self.viewer.axes.get_ylabel(),
             titlefont=dict(
                 family=DEFAULT_FONT,
-                size=2*self.viewer.axes.yaxis.get_label().get_size(),
+                size=2 * self.viewer.axes.yaxis.get_label().get_size(),
                 color=settings.FOREGROUND_COLOR),
             showgrid=False,
             showspikes=False,
@@ -112,7 +108,7 @@ class PlotlyHistogram1DExport(Tool):
             showticklabels=True,
             tickfont=dict(
                 family=DEFAULT_FONT,
-                size=1.5*self.viewer.axes.yaxis.get_ticklabels()[
+                size=1.5 * self.viewer.axes.yaxis.get_ticklabels()[
                     0].get_fontsize(),
                 color=settings.FOREGROUND_COLOR),
         )
@@ -128,83 +124,39 @@ class PlotlyHistogram1DExport(Tool):
 
             if layer_state.visible and layer.enabled:
 
-                x = layer_state.layer[self.viewer.state.x_att]
+                # The x values should be at the midpoints between successive pairs of edge values
+                edges, y = layer_state.histogram
+                x = [0.5 * (edges[i] + edges[i + 1]) for i in range(len(edges) - 1)]
 
                 marker = {}
 
                 # set all bars to be the same color
                 if layer_state.color != '0.35':
-                        marker['color'] = layer_state.color
+                    marker['color'] = layer_state.color
                 else:
                     marker['color'] = 'gray'
 
-                # set the opacity
+                # set the opacity and remove bar borders
                 marker['opacity'] = layer_state.alpha
-
-                # check whether to show cumulative
-                cumulative = {}
-                if self.viewer.state.cumulative:
-                    cumulative['currentbin'] = 'include'
-                    cumulative['enabled'] = True
+                marker['line'] = dict(width=0)
 
                 # set log
                 if self.viewer.state.x_log:
                     fig.update_xaxes(type='log', dtick=1, minor_ticks='outside',
-                        range=[np.log10(self.viewer.state.x_min), np.log10(self.viewer.state.x_max)]
-                    )
+                                     range=[np.log10(self.viewer.state.x_min), np.log10(self.viewer.state.x_max)]
+                                     )
                 if self.viewer.state.y_log:
                     fig.update_yaxes(type='log', dtick=1, minor_ticks='outside',
-                        range=[np.log10(self.viewer.state.y_min), np.log10(self.viewer.state.y_max)]
-                    )
-
-                # set xbins
-                # when the max bin edge is the same as the max x value, plotly excludes this value
-                # so there is always one less in the frequency if these numbers are equal
-                if self.viewer.state.x_log:
-                    start_val = np.log10(self.viewer.state.hist_x_min)
-                    end_val = self.viewer.state.hist_x_max
-                    # end_val += end_val * 0.001
-                    end_val *= np.log10(end_val)
-                else:
-                    start_val = self.viewer.state.hist_x_min
-                    end_val = self.viewer.state.hist_x_max
-                    # end_val += end_val * 0.001
-                print(self.viewer.state.hist_n_bin)
-                xbins = dict(
-                    start=start_val,
-                    end=end_val,
-                    size=(self.viewer.state.hist_x_max - self.viewer.state.hist_x_min) / 
-                        self.viewer.state.hist_n_bin
-                )
-
-                # add hover info to layer
-
-                if np.sum(dialog.checked_dictionary[layer_state.layer.label]) == 0:
-                    hoverinfo = 'skip'
-                    hovertext = None
-                else:
-                    hoverinfo = 'text'
-                    hovertext = ["" for i in range((layer_state.layer.shape[0]))]
-                    for i in range(0, len(layer_state.layer.components)):
-                        if dialog.checked_dictionary[layer_state.layer.label][i]:
-                            hover_data = layer_state.layer[layer_state.layer.components[i].label]
-                            for k in range(0, len(hover_data)):
-                                hovertext[k] = (hovertext[k] + "{}: {} <br>"
-                                                .format(layer_state.layer.components[i].label,
-                                                        hover_data[k]))
+                                     range=[np.log10(self.viewer.state.y_min), np.log10(self.viewer.state.y_max)]
+                                     )
 
                 # add layer to dict
                 hist_info = dict(
                     x=x,
-                    nbinsx=self.viewer.state.hist_n_bin,
-                    xbins=xbins,
+                    y=y,
                     marker=marker,
-                    cumulative=cumulative,
-                    hoverinfo=hoverinfo,
-                    hovertext=hovertext,
-                    name=layer_state.layer.label,
-                    autobinx=False
+                    name=layer_state.layer.label
                 )
-                fig.add_histogram(**hist_info)
+                fig.add_bar(**hist_info)
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -1,0 +1,210 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from qtpy import compat
+from glue.config import viewer_tool, settings
+
+from glue.core import DataCollection, Data
+
+from .. import save_hover
+
+try:
+    from glue.viewers.common.qt.tool import Tool
+except ImportError:
+    from glue.viewers.common.tool import Tool
+
+from glue_plotly import PLOTLY_LOGO
+
+from plotly.offline import plot
+import plotly.graph_objs as go
+from glue.core.qt.dialogs import warn
+
+DEFAULT_FONT = 'Arial, sans-serif'
+
+
+@viewer_tool
+class PlotlyHistogram1DExport(Tool):
+
+    icon = PLOTLY_LOGO
+    tool_id = 'save:plotlyhist'
+    action_text = 'Save Plotly HTML page'
+    tool_tip = 'Save Plotly HTML page'
+
+    def activate(self):
+
+        # grab hover info
+        dc_hover = DataCollection()
+        for layer in self.viewer.layers:
+            layer_state = layer.state
+            if layer_state.visible and layer.enabled:
+                data = Data(label=layer_state.layer.label)
+                for component in layer_state.layer.components:
+                    data[component.label] = np.ones(10)
+                dc_hover.append(data)
+
+        checked_dictionary = {}
+
+        # figure out which hover info user wants to display
+        for layer in self.viewer.layers:
+            layer_state = layer.state
+            if layer_state.visible and layer.enabled:
+                checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(bool)
+
+        dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
+        proceed = warn('Histogram plotly may look different', 'Plotly and Matlotlib binning methods differ and your graph may look different when exported. Do you want to proceed?',
+                    default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
+        if not proceed:
+            return
+        dialog.exec_()
+
+        filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+
+        width, height = self.viewer.figure.get_size_inches()*self.viewer.figure.dpi
+
+        # set the aspect ratio of the axes, the tick label size, the axis label
+        # sizes, and the axes limits
+        layout_config = dict(
+            margin=dict(r=50, l=50, b=50, t=50),  # noqa
+            width=1200,
+            height=1200*height/width,  # scale axis correctly
+            paper_bgcolor=settings.BACKGROUND_COLOR,
+            plot_bgcolor=settings.BACKGROUND_COLOR
+        )
+
+        x_axis = dict(
+            title=self.viewer.axes.get_xlabel(),
+            titlefont=dict(
+                family=DEFAULT_FONT,
+                size=2*self.viewer.axes.xaxis.get_label().get_size(),
+                color=settings.FOREGROUND_COLOR
+            ),
+            showspikes=False,
+            linecolor=settings.FOREGROUND_COLOR,
+            tickcolor=settings.FOREGROUND_COLOR,
+            mirror=True,
+            ticks='outside',
+            showline=True,
+            showgrid=False,
+            showticklabels=True,
+            tickfont=dict(
+                family=DEFAULT_FONT,
+                size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
+                    0].get_fontsize(),
+                color=settings.FOREGROUND_COLOR),
+            range=[self.viewer.state.x_min, self.viewer.state.x_max]
+        )
+        y_axis = dict(
+            title=self.viewer.axes.get_ylabel(),
+            titlefont=dict(
+                family=DEFAULT_FONT,
+                size=2*self.viewer.axes.yaxis.get_label().get_size(),
+                color=settings.FOREGROUND_COLOR),
+            showgrid=False,
+            showspikes=False,
+            linecolor=settings.FOREGROUND_COLOR,
+            tickcolor=settings.FOREGROUND_COLOR,
+            zeroline=False,
+            mirror=True,
+            ticks='outside',
+            showline=True,
+            range=[self.viewer.state.y_min, self.viewer.state.y_max],
+            showticklabels=True,
+            tickfont=dict(
+                family=DEFAULT_FONT,
+                size=1.5*self.viewer.axes.yaxis.get_ticklabels()[
+                    0].get_fontsize(),
+                color=settings.FOREGROUND_COLOR),
+        )
+        layout_config.update(xaxis=x_axis, yaxis=y_axis)
+
+        layout = go.Layout(**layout_config)
+
+        fig = go.Figure(layout=layout)
+
+        for layer in self.viewer.layers:
+
+            layer_state = layer.state
+
+            if layer_state.visible and layer.enabled:
+
+                x = layer_state.layer[self.viewer.state.x_att]
+
+                marker = {}
+
+                # set all bars to be the same color
+                if layer_state.color != '0.35':
+                        marker['color'] = layer_state.color
+                else:
+                    marker['color'] = 'gray'
+
+                # set the opacity
+                marker['opacity'] = layer_state.alpha
+
+                # check whether to show cumulative
+                cumulative = {}
+                if self.viewer.state.cumulative:
+                    cumulative['currentbin'] = 'include'
+                    cumulative['enabled'] = True
+
+                # set log
+                if self.viewer.state.x_log:
+                    fig.update_xaxes(type='log', dtick=1, minor_ticks='outside',
+                        range=[np.log10(self.viewer.state.x_min), np.log10(self.viewer.state.x_max)]
+                    )
+                if self.viewer.state.y_log:
+                    fig.update_yaxes(type='log', dtick=1, minor_ticks='outside',
+                        range=[np.log10(self.viewer.state.y_min), np.log10(self.viewer.state.y_max)]
+                    )
+
+                # set xbins
+                # when the max bin edge is the same as the max x value, plotly excludes this value
+                # so there is always one less in the frequency if these numbers are equal
+                if self.viewer.state.x_log:
+                    start_val = np.log10(self.viewer.state.hist_x_min)
+                    end_val = self.viewer.state.hist_x_max
+                    # end_val += end_val * 0.001
+                    end_val *= np.log10(end_val)
+                else:
+                    start_val = self.viewer.state.hist_x_min
+                    end_val = self.viewer.state.hist_x_max
+                    # end_val += end_val * 0.001
+                print(self.viewer.state.hist_n_bin)
+                xbins = dict(
+                    start=start_val,
+                    end=end_val,
+                    size=(self.viewer.state.hist_x_max - self.viewer.state.hist_x_min) / 
+                        self.viewer.state.hist_n_bin
+                )
+
+                # add hover info to layer
+
+                if np.sum(dialog.checked_dictionary[layer_state.layer.label]) == 0:
+                    hoverinfo = 'skip'
+                    hovertext = None
+                else:
+                    hoverinfo = 'text'
+                    hovertext = ["" for i in range((layer_state.layer.shape[0]))]
+                    for i in range(0, len(layer_state.layer.components)):
+                        if dialog.checked_dictionary[layer_state.layer.label][i]:
+                            hover_data = layer_state.layer[layer_state.layer.components[i].label]
+                            for k in range(0, len(hover_data)):
+                                hovertext[k] = (hovertext[k] + "{}: {} <br>"
+                                                .format(layer_state.layer.components[i].label,
+                                                        hover_data[k]))
+
+                # add layer to dict
+                hist_info = dict(
+                    x=x,
+                    nbinsx=self.viewer.state.hist_n_bin,
+                    xbins=xbins,
+                    marker=marker,
+                    cumulative=cumulative,
+                    hoverinfo=hoverinfo,
+                    hovertext=hovertext,
+                    name=layer_state.layer.label,
+                    autobinx=False
+                )
+                fig.add_histogram(**hist_info)
+
+        plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
+from re import sub
 import numpy as np
 
 from qtpy import compat
 from glue.config import viewer_tool, settings
-
 from glue.core import DataCollection, Data, Subset
 
 try:
@@ -21,8 +21,7 @@ DEFAULT_FONT = 'Arial, sans-serif'
 
 
 def cleaned_labels(labels):
-    cleaned = [label.replace('\\mathregular', '\\mathrm') for label in labels]
-    cleaned = [label.replace('\\mathdefault', '\\mathrm') for label in cleaned]
+    cleaned = [sub(r'\\math(default|regular)', r'\\mathrm', label) for label in labels]
     for j in range(len(cleaned)):
         label = cleaned[j]
         if '$' in label:
@@ -33,10 +32,10 @@ def cleaned_labels(labels):
 def ticks_values(axes, axis):
     index = 1 if axis == 'y' else 0
     minor_getters = [axes.get_xminorticklabels, axes.get_yminorticklabels]
-    major_getters = [axes.get_xticklabels, axes.get_yticklabels]
     minor_ticks = minor_getters[index]()
     if not (minor_ticks and any(t.get_text() for t in minor_ticks)):
         return [], []
+    major_getters = [axes.get_xticklabels, axes.get_yticklabels]
     major_ticks = major_getters[index]()
     vals, text = [], []
     for tick in major_ticks + minor_ticks:

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -5,9 +5,7 @@ import numpy as np
 from qtpy import compat
 from glue.config import viewer_tool, settings
 
-from glue.core import DataCollection, Data
-
-from .. import save_hover
+from glue.core import DataCollection, Data, Subset
 
 try:
     from glue.viewers.common.qt.tool import Tool
@@ -147,13 +145,17 @@ class PlotlyHistogram1DExport(Tool):
                                      range=[np.log10(self.viewer.state.y_min), np.log10(self.viewer.state.y_max)]
                                      )
 
+                label = layer.layer.label
+                if isinstance(layer.layer, Subset):
+                    label += " ({0})".format(layer.layer.data.label)
+
                 # add layer to dict
                 hist_info = dict(
                     x=x,
                     y=y,
                     hoverinfo='skip',
                     marker=marker,
-                    name=layer_state.layer.label
+                    name=label
                 )
                 fig.add_bar(**hist_info)
 

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -149,14 +149,23 @@ class PlotlyHistogram1DExport(Tool):
                 if isinstance(layer.layer, Subset):
                     label += " ({0})".format(layer.layer.data.label)
 
-                # add layer to dict
-                hist_info = dict(
-                    x=x,
-                    y=y,
-                    hoverinfo='skip',
-                    marker=marker,
-                    name=label
-                )
-                fig.add_bar(**hist_info)
+                hist_info = dict(hoverinfo="skip", marker=marker, name=label)
+                if self.viewer.state.x_log:
+                    for i in range(len(x)):
+                        hist_info.update(
+                            legendgroup=label,
+                            showlegend=i is 0,
+                            x=[x[i]],
+                            y=[y[i]],
+                            width=edges[i+1] - edges[i],
+                        )
+                        fig.add_bar(**hist_info)
+                else:
+                    hist_info.update(
+                        x=x,
+                        y=y,
+                        width=edges[1] - edges[0],
+                    )
+                    fig.add_bar(**hist_info)
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from qtpy import compat
 from glue.config import viewer_tool, settings
-from glue.core import DataCollection, Data, Subset
+from glue.core import Subset
 
 try:
     from glue.viewers.common.qt.tool import Tool
@@ -55,24 +55,6 @@ class PlotlyHistogram1DExport(Tool):
     tool_tip = 'Save Plotly HTML page'
 
     def activate(self):
-
-        # grab hover info
-        dc_hover = DataCollection()
-        for layer in self.viewer.layers:
-            layer_state = layer.state
-            if layer_state.visible and layer.enabled:
-                data = Data(label=layer_state.layer.label)
-                for component in layer_state.layer.components:
-                    data[component.label] = np.ones(10)
-                dc_hover.append(data)
-
-        checked_dictionary = {}
-
-        # figure out which hover info user wants to display
-        for layer in self.viewer.layers:
-            layer_state = layer.state
-            if layer_state.visible and layer.enabled:
-                checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(bool)
 
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
 

--- a/glue_plotly/html_exporters/tests/test_histogram.py
+++ b/glue_plotly/html_exporters/tests/test_histogram.py
@@ -5,14 +5,6 @@ from mock import patch
 from glue.core import Data
 from glue.app.qt import GlueApplication
 from glue.viewers.histogram.qt import HistogramViewer
-from glue_plotly.save_hover import SaveHoverDialog
-
-
-def auto_accept():
-    def exec_replacement(self):
-        self.select_all()
-        self.accept()
-    return exec_replacement
 
 
 class TestHistogram:
@@ -42,8 +34,7 @@ class TestHistogram:
         output_path = tmpdir.join(output_filename).strpath
         with patch('qtpy.compat.getsavefilename') as fd:
             fd.return_value = output_path, 'html'
-            with patch.object(SaveHoverDialog, 'exec_', auto_accept()):
-                self.tool.activate()
+            self.tool.activate()
         return output_path
 
     def test_default(self, tmpdir):

--- a/glue_plotly/html_exporters/tests/test_histogram.py
+++ b/glue_plotly/html_exporters/tests/test_histogram.py
@@ -1,0 +1,53 @@
+import os
+
+from mock import patch
+
+from glue.core import Data
+from glue.app.qt import GlueApplication
+from glue.viewers.histogram.qt import HistogramViewer
+from glue_plotly.save_hover import SaveHoverDialog
+
+
+def auto_accept():
+    def exec_replacement(self):
+        self.select_all()
+        self.accept()
+    return exec_replacement
+
+
+class TestHistogram:
+
+    def setup_method(self, method):
+        self.data = Data(x=[40, 41, 37, 63, 78, 35, 19, 100, 35, 86, 84, 99,
+                            87, 56, 2, 71, 22, 36, 10, 1, 26, 70, 45, 20, 8],
+                         label='d1')
+        self.app = GlueApplication()
+        self.app.session.data_collection.append(self.data)
+        self.viewer = self.app.new_data_viewer(HistogramViewer)
+        self.viewer.add_data(self.data)
+        for subtool in self.viewer.toolbar.tools['save'].subtools:
+            if subtool.tool_id == 'save:plotlyhist':
+                self.tool = subtool
+                break
+        else:
+            raise Exception("Could not find save:plotlyhist tool in viewer")
+
+    def teardown_method(self, method):
+        self.viewer.close(warn=False)
+        self.viewer = None
+        self.app.close()
+        self.app = None
+
+    def export_figure(self, tmpdir, output_filename):
+        output_path = tmpdir.join(output_filename).strpath
+        with patch('qtpy.compat.getsavefilename') as fd:
+            fd.return_value = output_path, 'html'
+            with patch.object(SaveHoverDialog, 'exec_', auto_accept()):
+                self.tool.activate()
+        return output_path
+
+    def test_default(self, tmpdir):
+        self.viewer.state.x_att = self.data.id['x']
+        self.viewer.state.hist_n_bin = 6
+        output_path = self.export_figure(tmpdir, 'test_default.html')
+        assert os.path.exists(output_path)


### PR DESCRIPTION
This is the next installment in the series of updates from @victoriaono and myself. This PR adds an exporter for the histogram viewer. The main things I think are worth mentioning:

* Plotly has its own histogram trace, but its binning can differ from glue's, and it doesn't support binning logarithmically (see issue 1844 in the plotly repository). The solution that I landed on is to use Plotly's bar traces rather than a histogram. This allows us to use the heavy lifting that we've already done in glue, by using the layer state's `histogram` property. This directly gives us the positions and heights of the bars in our chart.
* For plots with a log x-axis, this means that the width of each bar is different (in axis units, not visually). AFAICT Plotly's bar trace doesn't support setting a different width for each bar. To work around this, when the x-axis is log we create a separate bar trace for each bin, with an appropriate width, and group them into the same legend group.
* For axis labels, I've taken the position that when glue is using minor ticks, we explicitly set the tick values and text in Plotly. An example of this would be on log axes where the range is smaller than the distance between successive ticks.