### PR TITLE
DOC: update order of autogenerated Changelog entries

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,12 +7,12 @@ changelog:
       - skip-changelog
 
   categories:
-    - title: Bug Fixes
-      labels:
-        - bug
     - title: New Features
       labels:
         - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
     - title: Documentation
       labels:
         - documentation

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
-|Build Status| |Coverage Status|
+|Actions Status| |Coverage Status|
 
 Experimental plot.ly plugin for glue
 ------------------------------------
 
-.. image:: https://dev.azure.com/glue-viz/glue-plotly/_apis/build/status/glue-viz.glue-plotly?branchName=master
-   :target: https://dev.azure.com/glue-viz/glue-plotly/_build/results?buildId=27&view=logs
+.. |Actions Status| image:: https://github.com/glueviz/glue-plotly/workflows/CI/badge.svg
+    :target: https://github.com/glueviz/glue-plotly/actions
+    :alt: Glue's GitHub Actions CI Status
+.. |Coverage Status| image:: https://codecov.io/gh/glue-viz/glue-plotly/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/glue-viz/glue-plotly


### PR DESCRIPTION
## Description
The just-linked docs recommend to put important changes first, but the `release.yml` rules are adding Bug Fixes first, then New Features.
Reversing this and also fixing README buttons.