### PR TITLE
Improve feedback to user from exporters

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -8,6 +8,7 @@ except DistributionNotFound:
     pass
 
 PLOTLY_LOGO = os.path.abspath(os.path.join(os.path.dirname(__file__), 'logo.png'))
+PLOTLY_ERROR_MESSAGE = "An error occurred during the export to Plotly:"
 
 
 def setup():

--- a/glue_plotly/export_dialog.py
+++ b/glue_plotly/export_dialog.py
@@ -1,0 +1,35 @@
+
+from qtpy.QtWidgets import QDialog, QLabel, QVBoxLayout
+from qtpy.QtCore import QTimer, Qt
+
+
+class ExportDialog(QDialog):
+
+    max_dots = 3
+    _BASE_MESSAGE = "Exporting to Plotly"
+
+    def __init__(self, parent=None):
+        super(ExportDialog, self).__init__(parent=parent, flags=Qt.FramelessWindowHint)
+
+        self.label = QLabel()
+        self.label.setText(self._BASE_MESSAGE)
+        self.layout = QVBoxLayout()
+        self.layout.addWidget(self.label)
+        self.setLayout(self.layout)
+
+        ending_spaces = " " * self.max_dots
+        if not self.label.text().endswith(ending_spaces):
+            self.label.setText(self.label.text() + ending_spaces)
+        self.n_dots = 0
+        self.timer = QTimer()
+        self.timer.timeout.connect(self._on_timer_update)
+        self.timer.start(750)
+
+    def _on_timer_update(self):
+        self.n_dots = (self.n_dots + 1) % (self.max_dots + 1)
+        text = self._BASE_MESSAGE + "." * self.n_dots
+        self.label.setText(text)
+
+    def close(self):
+        super(ExportDialog, self).close()
+        self.timer.stop()

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -5,6 +5,7 @@ import numpy as np
 from qtpy import compat
 from glue.config import viewer_tool, settings
 from glue.core import Subset
+from glue.utils.qt import messagebox_on_error
 
 from ..utils import ticks_values
 
@@ -13,7 +14,7 @@ try:
 except ImportError:
     from glue.viewers.common.tool import Tool
 
-from glue_plotly import PLOTLY_LOGO
+from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
 
 from plotly.offline import plot
 import plotly.graph_objs as go
@@ -28,8 +29,8 @@ class PlotlyHistogram1DExport(Tool):
     action_text = 'Save Plotly HTML page'
     tool_tip = 'Save Plotly HTML page'
 
+    @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
     def activate(self):
-
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
 
         width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -32,6 +32,8 @@ class PlotlyHistogram1DExport(Tool):
     @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
     def activate(self):
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+        if not filename:
+            return
 
         width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
 

--- a/glue_plotly/html_exporters/image.py
+++ b/glue_plotly/html_exporters/image.py
@@ -7,6 +7,7 @@ import numpy as np
 from matplotlib.colors import rgb2hex, to_rgb, Normalize
 
 from qtpy import compat
+from qtpy.QtWidgets import QDialog
 
 from glue.config import viewer_tool, settings
 from glue.core import DataCollection, Data
@@ -423,9 +424,13 @@ class PlotlyImage2DExport(Tool):
                         bool)
 
             dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-            dialog.exec_()
+            result = dialog.exec_()
+            if result == QDialog.Rejected:
+                return
 
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+        if not filename:
+            return
 
         worker = Worker(self._export_to_plotly, filename, scatter_layers,
                         image_layers, image_subset_layers, checked_dictionary)

--- a/glue_plotly/html_exporters/image.py
+++ b/glue_plotly/html_exporters/image.py
@@ -7,25 +7,27 @@ import numpy as np
 from matplotlib.colors import rgb2hex, to_rgb, Normalize
 
 from qtpy import compat
-from glue.config import viewer_tool, settings
 
+from glue.config import viewer_tool, settings
 from glue.core import DataCollection, Data
 from glue.core.exceptions import IncompatibleAttribute
 from glue.utils import ensure_numerical
+from glue.utils.qt import messagebox_on_error
+from glue.utils.qt.threading import Worker
 from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
 from glue.viewers.image.composite_array import STRETCHES
 from glue.viewers.image.state import ImageLayerState, ImageSubsetLayerState
 from glue.viewers.scatter.state import ScatterLayerState
 
-from .. import save_hover
 from ..utils import cleaned_labels
+from .. import save_hover, export_dialog
 
 try:
     from glue.viewers.common.qt.tool import Tool
 except ImportError:
     from glue.viewers.common.tool import Tool
 
-from glue_plotly import PLOTLY_LOGO
+from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
 
 import plotly.graph_objects as go
 from plotly.offline import plot
@@ -48,44 +50,8 @@ class PlotlyImage2DExport(Tool):
     action_text = 'Save Plotly HTML page'
     tool_tip = 'Save Plotly HTML page'
 
-    def activate(self):
-
-        # grab hover info
-        layers = sorted([layer for layer in self.viewer.layers if layer.state.visible and layer.enabled],
-                        key=lambda layer: layer.zorder)
-        scatter_layers, image_layers, image_subset_layers = [], [], []
-        for layer in layers:
-            if isinstance(layer.state, ImageLayerState):
-                image_layers.append(layer)
-            elif isinstance(layer.state, ImageSubsetLayerState):
-                image_subset_layers.append(layer)
-            elif isinstance(layer.state, ScatterLayerState):
-                scatter_layers.append(layer)
-
-        if len(scatter_layers) > 0:
-            dc_hover = DataCollection()
-            for layer in scatter_layers:
-                layer_state = layer.state
-                if layer_state.visible and layer.enabled:
-                    data = Data(label=layer_state.layer.label)
-                    for component in layer_state.layer.components:
-                        data[component.label] = np.ones(10)
-                    dc_hover.append(data)
-
-            checked_dictionary = {}
-
-            # figure out which hover info user wants to display
-            for layer in scatter_layers:
-                layer_state = layer.state
-                if layer_state.visible and layer.enabled:
-                    checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(
-                        bool)
-
-            dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-            dialog.exec_()
-
-        filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
-
+    @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
+    def _export_to_plotly(self, filename, scatter_layers, image_layers, image_subset_layers, checked_dictionary):
         width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
 
         xmin, xmax = self.viewer.axes.get_xlim()
@@ -380,14 +346,14 @@ class PlotlyImage2DExport(Tool):
 
             # add hover info to layer
 
-            if np.sum(dialog.checked_dictionary[layer_state.layer.label]) == 0:
+            if np.sum(checked_dictionary[layer_state.layer.label]) == 0:
                 hoverinfo = 'skip'
                 hovertext = None
             else:
                 hoverinfo = 'text'
                 hovertext = ["" for _ in range((layer_state.layer.shape[0]))]
                 for i in range(0, len(layer_state.layer.components)):
-                    if dialog.checked_dictionary[layer_state.layer.label][i]:
+                    if checked_dictionary[layer_state.layer.label][i]:
                         hover_data = layer_state.layer[layer_state.layer.components[i].label]
                         for k in range(0, len(hover_data)):
                             hovertext[k] = (hovertext[k] + "{}: {} <br>"
@@ -419,7 +385,52 @@ class PlotlyImage2DExport(Tool):
                                   yaxis='y2' if secondary_y else 'y')
             layers_to_add.append([fig.add_heatmap, secondary_info])
 
-        for func, data in layers_to_add:
+        for index, (func, data) in enumerate(layers_to_add):
             func(**data)
 
         plot(fig, include_mathjax='cdn', filename=filename, auto_open=False)
+
+    def activate(self):
+
+        # grab hover info
+        layers = sorted([layer for layer in self.viewer.layers if layer.state.visible and layer.enabled],
+                        key=lambda layer: layer.zorder)
+        scatter_layers, image_layers, image_subset_layers = [], [], []
+        for layer in layers:
+            if isinstance(layer.state, ImageLayerState):
+                image_layers.append(layer)
+            elif isinstance(layer.state, ImageSubsetLayerState):
+                image_subset_layers.append(layer)
+            elif isinstance(layer.state, ScatterLayerState):
+                scatter_layers.append(layer)
+
+        checked_dictionary = {}
+        if len(scatter_layers) > 0:
+            dc_hover = DataCollection()
+            for layer in scatter_layers:
+                layer_state = layer.state
+                if layer_state.visible and layer.enabled:
+                    data = Data(label=layer_state.layer.label)
+                    for component in layer_state.layer.components:
+                        data[component.label] = np.ones(10)
+                    dc_hover.append(data)
+
+            # figure out which hover info user wants to display
+            for layer in scatter_layers:
+                layer_state = layer.state
+                if layer_state.visible and layer.enabled:
+                    checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(
+                        bool)
+
+            dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
+            dialog.exec_()
+
+        filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+
+        worker = Worker(self._export_to_plotly, filename, scatter_layers,
+                        image_layers, image_subset_layers, checked_dictionary)
+        exp_dialog = export_dialog.ExportDialog(parent=self.viewer)
+        worker.result.connect(exp_dialog.close)
+        worker.error.connect(exp_dialog.close)
+        worker.start()
+        exp_dialog.exec_()

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -5,6 +5,7 @@ import matplotlib.colors as colors
 from matplotlib.colors import Normalize
 
 from qtpy import compat
+from qtpy.QtWidgets import QDialog
 from glue.config import viewer_tool
 
 from glue.core import DataCollection, Data
@@ -57,9 +58,13 @@ class PlotlyScatter2DStaticExport(Tool):
                 checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(bool)
 
         dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-        dialog.exec_()
+        result = dialog.exec_()
+        if result == QDialog.Rejected:
+            return
 
         filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+        if not filename:
+            return
 
         width, height = self.viewer.figure.get_size_inches()*self.viewer.figure.dpi
 

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -9,6 +9,7 @@ from glue.config import viewer_tool
 
 from glue.core import DataCollection, Data
 from glue.utils import ensure_numerical
+from glue.utils.qt import messagebox_on_error
 
 from .. import save_hover
 
@@ -17,7 +18,7 @@ try:
 except ImportError:
     from glue.viewers.common.tool import Tool
 
-from glue_plotly import PLOTLY_LOGO
+from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
 
 from plotly.offline import plot
 import plotly.graph_objs as go
@@ -34,6 +35,7 @@ class PlotlyScatter2DStaticExport(Tool):
     action_text = 'Save Plotly HTML page'
     tool_tip = 'Save Plotly HTML page'
 
+    @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
     def activate(self):
 
         # grab hover info

--- a/glue_plotly/html_exporters/scatter3d.py
+++ b/glue_plotly/html_exporters/scatter3d.py
@@ -5,6 +5,7 @@ import matplotlib.colors as colors
 from matplotlib.colors import Normalize
 
 from qtpy import compat
+from qtpy.QtWidgets import QDialog
 
 from glue.config import viewer_tool, settings
 from glue.core import DataCollection, Data
@@ -337,11 +338,15 @@ class PlotlyScatter3DStaticExport(Tool):
             return
 
         dialog = save_hover.SaveHoverDialog(data_collection=dc_hover, checked_dictionary=checked_dictionary)
-        dialog.exec_()
+        result = dialog.exec_()
+        if result == QDialog.Rejected:
+            return
 
         # query filename
         filename, _ = compat.getsavefilename(
             parent=self.viewer, basedir="plot.html")
+        if not filename:
+            return
 
         worker = Worker(self._export_to_plotly, filename, checked_dictionary)
         exp_dialog = export_dialog.ExportDialog(parent=self.viewer)


### PR DESCRIPTION
As Alyssa (and maybe others) have pointed out in glue meetings, the Plotly exporters are currently not great about giving the user any feedback about things that happen. In particular, there are two main issues:
* The exporters currently fail silently. Any error messages do go into the error console, but if a user doesn't know to look there, they won't know anything went wrong until they go try to open their exported plot.
* There isn't a good indication of when the export is complete - the user just has to wait until they are able to manipulate glue again to know that things are finished, as the export blocks the UI. This is particularly noticeable for the 3D scatter and image exporters, which can often take a nontrivial amount of time to complete.

This PR looks to solve these two issues in the following ways:
* Use the `messagebox_on_error` decorator to let the user know when an error has occurred. This prevents the error message from going into the error console, but the message box shows the entire traceback, so I think this is better than the export failing silently.
* For the 3D scatter and image exporters, add a blocking dialog that tells them that the Plotly export is still going. This dialog closes once the export is complete. This way users have a clear way to know when the export has finished. To do this, I split out the code that does the actual Plotly export from the activate function, since we don't want this blocking dialog to run until after the user has finished selecting options (i.e. selecting hover info and choosing a filepath).

Edit: I've added one more feature to this PR, which is to cancel the export if the user selects cancel on either the hover dialog (where applicable) and the filename dialog. Currently, clicking cancel on either of these windows has no effect and the export continues (if the user cancels on the filename dialog, the export is still done and output to a file named `.html` - easy to miss on Linux/Mac!)