### PR TITLE
Improvements to 2D scatter exporter

### DIFF
--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -352,6 +352,18 @@ class PlotlyScatter2DStaticExport(Tool):
                                         showlegend=False)
                                 )
 
+                # set log
+                if self.viewer.state.x_log:
+                    fig.update_xaxes(type='log', dtick=1, minor_ticks='outside',
+                                     range=[np.log10(self.viewer.state.x_min),
+                                            np.log10(self.viewer.state.x_max)]
+                                     )
+                if self.viewer.state.y_log:
+                    fig.update_yaxes(type='log', dtick=1, minor_ticks='outside',
+                                     range=[np.log10(self.viewer.state.y_min),
+                                            np.log10(self.viewer.state.y_max)]
+                                     )
+
                 # add hover info to layer
 
                 if np.sum(dialog.checked_dictionary[layer_state.layer.label]) == 0:

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-from turtle import color
 
 import numpy as np
 import matplotlib.colors as colors
@@ -28,13 +27,11 @@ from plotly.offline import plot
 import plotly.graph_objs as go
 import plotly.figure_factory as ff
 
-
 DEFAULT_FONT = 'Arial, sans-serif'
 
 
 @viewer_tool
 class PlotlyScatter2DStaticExport(Tool):
-
     icon = PLOTLY_LOGO
     tool_id = 'save:plotly2d'
     action_text = 'Save Plotly HTML page'
@@ -70,7 +67,7 @@ class PlotlyScatter2DStaticExport(Tool):
         if not filename:
             return
 
-        width, height = self.viewer.figure.get_size_inches()*self.viewer.figure.dpi
+        width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
 
         polar = getattr(self.viewer.state, 'using_polar', False)
         degrees = polar and self.viewer.state.using_degrees
@@ -84,7 +81,7 @@ class PlotlyScatter2DStaticExport(Tool):
         layout_config = dict(
             margin=dict(r=50, l=50, b=50, t=50),  # noqa
             width=1200,
-            height=1200*height/width,  # scale axis correctly
+            height=1200 * height / width,  # scale axis correctly
             paper_bgcolor=settings.BACKGROUND_COLOR,
             plot_bgcolor=settings.BACKGROUND_COLOR
         )
@@ -102,7 +99,7 @@ class PlotlyScatter2DStaticExport(Tool):
                 tickprefix=theta_prefix,
                 tickfont=dict(
                     family=DEFAULT_FONT,
-                    size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
+                    size=1.5 * self.viewer.axes.xaxis.get_ticklabels()[
                         0].get_fontsize(),
                     color=settings.FOREGROUND_COLOR),
                 linecolor=settings.FOREGROUND_COLOR,
@@ -120,23 +117,23 @@ class PlotlyScatter2DStaticExport(Tool):
                 showline=False,
                 tickfont=dict(
                     family=DEFAULT_FONT,
-                    size=1.5*self.viewer.axes.yaxis.get_ticklabels()[
+                    size=1.5 * self.viewer.axes.yaxis.get_ticklabels()[
                         0].get_fontsize(),
                     color=settings.FOREGROUND_COLOR),
                 linecolor=settings.FOREGROUND_COLOR,
                 gridcolor=settings.FOREGROUND_COLOR
             )
             polar_layout = go.layout.Polar(angularaxis=angular_axis, radialaxis=radial_axis,
-                            bgcolor=settings.BACKGROUND_COLOR)
+                                           bgcolor=settings.BACKGROUND_COLOR)
             layout_config.update(polar=polar_layout)
-            
+
         else:
             angle_unit = None
             x_axis = dict(
                 title=self.viewer.axes.get_xlabel(),
                 titlefont=dict(
                     family=DEFAULT_FONT,
-                    size=2*self.viewer.axes.xaxis.get_label().get_size(),
+                    size=2 * self.viewer.axes.xaxis.get_label().get_size(),
                     color=settings.FOREGROUND_COLOR
                 ),
                 showspikes=False,
@@ -150,7 +147,7 @@ class PlotlyScatter2DStaticExport(Tool):
                 showticklabels=True,
                 tickfont=dict(
                     family=DEFAULT_FONT,
-                    size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
+                    size=1.5 * self.viewer.axes.xaxis.get_ticklabels()[
                         0].get_fontsize(),
                     color=settings.FOREGROUND_COLOR),
                 range=[self.viewer.state.x_min, self.viewer.state.x_max]
@@ -159,7 +156,7 @@ class PlotlyScatter2DStaticExport(Tool):
                 title=self.viewer.axes.get_ylabel(),
                 titlefont=dict(
                     family=DEFAULT_FONT,
-                    size=2*self.viewer.axes.yaxis.get_label().get_size(),
+                    size=2 * self.viewer.axes.yaxis.get_label().get_size(),
                     color=settings.FOREGROUND_COLOR),
                 showgrid=False,
                 showspikes=False,
@@ -173,7 +170,7 @@ class PlotlyScatter2DStaticExport(Tool):
                 showticklabels=True,
                 tickfont=dict(
                     family=DEFAULT_FONT,
-                    size=1.5*self.viewer.axes.yaxis.get_ticklabels()[
+                    size=1.5 * self.viewer.axes.yaxis.get_ticklabels()[
                         0].get_fontsize(),
                     color=settings.FOREGROUND_COLOR),
             )
@@ -228,7 +225,7 @@ class PlotlyScatter2DStaticExport(Tool):
                 else:
                     s = ensure_numerical(layer_state.layer[layer_state.size_att].ravel())
                     s = ((s - layer_state.size_vmin) /
-                                 (layer_state.size_vmax - layer_state.size_vmin))
+                         (layer_state.size_vmax - layer_state.size_vmin))
                     # The following ensures that the sizes are in the
                     # range 3 to 30 before the final size scaling.
                     np.clip(s, 0, 1, out=s)
@@ -241,10 +238,10 @@ class PlotlyScatter2DStaticExport(Tool):
                 marker['opacity'] = layer_state.alpha
 
                 # check whether or not to fill circles
-                
+
                 if not layer_state.fill:
                     marker['color'] = 'rgba(0,0,0,0)'
-                    marker['line'] = dict(width=1, 
+                    marker['line'] = dict(width=1,
                                           color=layer_state.color)
 
                 else:
@@ -253,23 +250,25 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 # add vectors
                 if layer_state.vector_visible:
-                    proceed = warn('Arrows may look different', 'Plotly and Matlotlib vector graphics differ and your graph may look different when exported. Do you want to proceed?',
-                    default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
+                    proceed = warn('Arrows may look different',
+                                   'Plotly and Matlotlib vector graphics differ and your graph may look different '
+                                   'when exported. Do you want to proceed?',
+                                   default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
                     if not proceed:
                         return
                     vx = layer_state.layer[layer_state.vx_att]
                     vy = layer_state.layer[layer_state.vy_att]
-                    vector_info = dict(scale = .1 * layer_state.vector_scaling,
-                                        arrow_scale=.3, line_width=3,
-                                        showlegend=False, hoverinfo='skip')
+                    vector_info = dict(scale=.1 * layer_state.vector_scaling,
+                                       arrow_scale=.3, line_width=3,
+                                       showlegend=False, hoverinfo='skip')
                     if layer_state.cmap_mode == 'Fixed':
                         fig = ff.create_quiver(x, y, vx, vy, **vector_info)
                         fig.update_traces(marker=dict(color=layer_color))
-                        
+
                     else:
                         # start with the first quiver to add the rest
                         fig = ff.create_quiver([x[0]], [y[0]], [vx[0]], [vy[0]],
-                                        **vector_info, line_color=marker['color'][0])
+                                               **vector_info, line_color=marker['color'][0])
                         for i in range(1, len(marker['color'])):
                             fig1 = ff.create_quiver([x[i]], [y[i]], [vx[i]], [vy[i]],
                                                     **vector_info,
@@ -277,14 +276,13 @@ class PlotlyScatter2DStaticExport(Tool):
                             fig.add_traces(data=fig1.data)
                     fig.update_layout(layout)
 
-
                 # add line properties
 
                 line = {}
 
                 if layer_state.line_visible:
                     # convert linestyle names from glue values to plotly values
-                    ls_dict = {'solid':'solid', 'dotted':'dot', 'dashed':'dash', 'dashdot':'dashdot'}
+                    ls_dict = {'solid': 'solid', 'dotted': 'dot', 'dashed': 'dash', 'dashdot': 'dashdot'}
                     line['dash'] = ls_dict[layer_state.linestyle]
                     line['width'] = layer_state.linewidth
 
@@ -301,21 +299,21 @@ class PlotlyScatter2DStaticExport(Tool):
                         indices = indices[1:len(x) * 2 - 1]
                         for i in range(len(segments)):
                             fig.add_trace(go.Scatter(
-                                        x=[segments[i][0][0], segments[i][1][0]], 
-                                        y=[segments[i][0][1], segments[i][1][1]], 
-                                        mode='lines', 
-                                        line=dict(
-                                            dash=ls_dict[layer_state.linestyle],
-                                            width=layer_state.linewidth,
-                                            color=rgb_str[indices[i]]),
-                                        showlegend=False,
-                                        hoverinfo='skip')
-                            )       
+                                x=[segments[i][0][0], segments[i][1][0]],
+                                y=[segments[i][0][1], segments[i][1][1]],
+                                mode='lines',
+                                line=dict(
+                                    dash=ls_dict[layer_state.linestyle],
+                                    width=layer_state.linewidth,
+                                    color=rgb_str[indices[i]]),
+                                showlegend=False,
+                                hoverinfo='skip')
+                            )
                 else:
                     mode = 'markers'
 
                 # add error bars
-                 
+
                 xerr = {}
                 if layer_state.xerr_visible:
                     xerr['type'] = 'data'
@@ -325,16 +323,16 @@ class PlotlyScatter2DStaticExport(Tool):
                     if layer_state.cmap_mode == 'Linear':
                         for i, bar in enumerate(xerr['array']):
                             fig.add_trace(go.Scatter(
-                                        x=[x[i]], 
-                                        y=[y[i]], 
-                                        mode='markers', 
-                                        error_x=dict(
-                                            type='data', color=marker['color'][i], 
-                                            array=[bar], visible=True),
-                                        marker=dict(color=marker['color'][i]),
-                                        showlegend=False)
-                                )
-                
+                                x=[x[i]],
+                                y=[y[i]],
+                                mode='markers',
+                                error_x=dict(
+                                    type='data', color=marker['color'][i],
+                                    array=[bar], visible=True),
+                                marker=dict(color=marker['color'][i]),
+                                showlegend=False)
+                            )
+
                 yerr = {}
                 if layer_state.yerr_visible:
                     yerr['type'] = 'data'
@@ -344,15 +342,15 @@ class PlotlyScatter2DStaticExport(Tool):
                     if layer_state.cmap_mode == 'Linear':
                         for i, bar in enumerate(yerr['array']):
                             fig.add_trace(go.Scatter(
-                                        x=[x[i]], 
-                                        y=[y[i]], 
-                                        mode='markers', 
-                                        error_y=dict(
-                                            type='data', color=marker['color'][i], 
-                                            array=[bar], visible=True),
-                                        marker=dict(color=marker['color'][i]),
-                                        showlegend=False)
-                                )
+                                x=[x[i]],
+                                y=[y[i]],
+                                mode='markers',
+                                error_y=dict(
+                                    type='data', color=marker['color'][i],
+                                    array=[bar], visible=True),
+                                marker=dict(color=marker['color'][i]),
+                                showlegend=False)
+                            )
 
                 # set log
                 if self.viewer.state.x_log:
@@ -405,12 +403,11 @@ class PlotlyScatter2DStaticExport(Tool):
                         x = x * 180 / np.pi
                         y = y * 180 / np.pi
                     fig.add_traces(data=go.Scattergeo(lon=x, lat=y))
-                    fig.update_geos(projection_type=proj_type, 
-                        showland=False, showcoastlines=False, showlakes=False,
-                        lataxis_showgrid=False, lonaxis_showgrid=False,
-                        bgcolor=settings.BACKGROUND_COLOR,
-                        framecolor=settings.FOREGROUND_COLOR)
+                    fig.update_geos(projection_type=proj_type,
+                                    showland=False, showcoastlines=False, showlakes=False,
+                                    lataxis_showgrid=False, lonaxis_showgrid=False,
+                                    bgcolor=settings.BACKGROUND_COLOR,
+                                    framecolor=settings.FOREGROUND_COLOR)
                     fig.update_traces(**scatter_info)
-
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -278,14 +278,22 @@ class PlotlyScatter2DStaticExport(Tool):
                         vy = r * np.sin(theta)
 
                     vmax = np.nanmax(np.hypot(vx, vy))
+                    vxmax = abs(np.nanmax(vx))
+                    vymax = abs(np.nanmax(vy))
                     # corner = np.nanmax(x), np.nanmax(y))
                     diag = np.hypot(self.viewer.state.x_max-self.viewer.state.x_min,
                                       self.viewer.state.y_max-self.viewer.state.y_min)
                     scale = 0.1 * (layer_state.vector_scaling) * (diag / vmax)
+                    angle = pi / 9 if layer_state.vector_arrowhead else 0
+                    xrange = abs(self.viewer.state.x_max-self.viewer.state.x_min)
+                    yrange = abs(self.viewer.state.y_max-self.viewer.state.y_min)
+                    minfrac = min(xrange / diag, yrange / diag)
+                    arrow_scale = 0.3 * minfrac if layer_state.vector_arrowhead else 0
+                    print(arrow_scale)
                     vector_info = dict(scale=scale,
-                                       angle=0,
+                                       angle=angle,
                                        name='quiver',
-                                       arrow_scale=0.00001,
+                                       arrow_scale=arrow_scale,
                                        line=dict(width=5),
                                        showlegend=False, hoverinfo='skip')
                     x_vec, y_vec = self._adjusted_vector_points(layer_state.vector_origin, scale, x, y, vx, vy)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -33,6 +33,7 @@ DEFAULT_FONT = 'Arial, sans-serif'
 SHOW_PLOTLY_VECTORS_2D_DIFFERENT = 'SHOW_PLOTLY_2D_VECTORS_DIFFERENT'
 settings.add(SHOW_PLOTLY_VECTORS_2D_DIFFERENT, True)
 
+
 @viewer_tool
 class PlotlyScatter2DStaticExport(Tool):
     icon = PLOTLY_LOGO
@@ -47,7 +48,7 @@ class PlotlyScatter2DStaticExport(Tool):
             return x, y
         elif origin == 'middle':
             return x - 0.5 * vx, y - 0.5 * vy
-        else: # tip
+        else:  # tip
             return x - vx, y - vy
 
     @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
@@ -280,7 +281,7 @@ class PlotlyScatter2DStaticExport(Tool):
 
                     vmax = np.nanmax(np.hypot(vx, vy))
                     diag = np.hypot(self.viewer.state.x_max-self.viewer.state.x_min,
-                                      self.viewer.state.y_max-self.viewer.state.y_min)
+                                    self.viewer.state.y_max-self.viewer.state.y_min)
                     scale = 0.05 * (layer_state.vector_scaling) * (diag / vmax) * (width / self.viewer.width())
                     xrange = abs(self.viewer.state.x_max-self.viewer.state.x_min)
                     yrange = abs(self.viewer.state.y_max-self.viewer.state.y_min)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -281,20 +281,14 @@ class PlotlyScatter2DStaticExport(Tool):
                     # corner = np.nanmax(x), np.nanmax(y))
                     diag = np.hypot(self.viewer.state.x_max-self.viewer.state.x_min,
                                       self.viewer.state.y_max-self.viewer.state.y_min)
-                    scale = 15 * (layer_state.vector_scaling / width) * (diag / vmax)
-                    angle = pi / 9 if layer_state.vector_arrowhead else 0
-                    arrow_scale = 0.2 if layer_state.vector_arrowhead else 0.00001
+                    scale = 0.1 * (layer_state.vector_scaling) * (diag / vmax)
                     vector_info = dict(scale=scale,
-                                       angle=angle,
+                                       angle=0,
                                        name='quiver',
                                        arrow_scale=0.00001,
                                        line=dict(width=5),
                                        showlegend=False, hoverinfo='skip')
                     x_vec, y_vec = self._adjusted_vector_points(layer_state.vector_origin, scale, x, y, vx, vy)
-                    print(layer_state.vector_origin)
-                    print(scale)
-                    for i in range(x.size):
-                        print(x[i], vx[i], x_vec[i])
                     if layer_state.cmap_mode == 'Fixed':
                         fig = ff.create_quiver(x_vec, y_vec, vx, vy, **vector_info)
                         fig.update_traces(marker=dict(color=layer_color))

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -194,12 +194,13 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 marker = {}
 
+                layer_color = layer_state.color
+                if layer_color == '0.35':
+                    layer_color = 'gray'
+
                 # set all points to be the same color
                 if layer_state.cmap_mode == 'Fixed':
-                    if layer_state.color != '0.35':
-                        marker['color'] = layer_state.color
-                    else:
-                        marker['color'] = 'gray'
+                    marker['color'] = layer_color
 
                 # color by some attribute
                 else:
@@ -263,10 +264,7 @@ class PlotlyScatter2DStaticExport(Tool):
                                         showlegend=False, hoverinfo='skip')
                     if layer_state.cmap_mode == 'Fixed':
                         fig = ff.create_quiver(x, y, vx, vy, **vector_info)
-                        if layer_state.color != '0.35':
-                            fig.update_traces(marker=dict(color=layer_state.color))
-                        else:
-                            fig.update_traces(marker=dict(color='gray'))
+                        fig.update_traces(marker=dict(color=layer_color))
                         
                     else:
                         # start with the first quiver to add the rest
@@ -291,10 +289,7 @@ class PlotlyScatter2DStaticExport(Tool):
                     line['width'] = layer_state.linewidth
 
                     if layer_state.cmap_mode == 'Fixed':
-                        if layer_state.color != '0.35':
-                            marker['color'] = layer_state.color
-                        else:
-                            marker['color'] = 'gray'
+                        marker['color'] = layer_color
                         mode = 'lines+markers'
                     else:
                         # set mode to markers and plot the colored line over it

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from turtle import color
 
 import numpy as np
 import matplotlib.colors as colors
@@ -6,11 +7,12 @@ from matplotlib.colors import Normalize
 
 from qtpy import compat
 from qtpy.QtWidgets import QDialog
-from glue.config import viewer_tool
 
+from glue.config import viewer_tool, settings
 from glue.core import DataCollection, Data
 from glue.utils import ensure_numerical
 from glue.utils.qt import messagebox_on_error
+from glue.viewers.scatter.layer_artist import plot_colored_line
 
 from .. import save_hover
 
@@ -18,11 +20,13 @@ try:
     from glue.viewers.common.qt.tool import Tool
 except ImportError:
     from glue.viewers.common.tool import Tool
+from glue.core.qt.dialogs import warn
 
 from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
 
 from plotly.offline import plot
 import plotly.graph_objs as go
+import plotly.figure_factory as ff
 
 
 DEFAULT_FONT = 'Arial, sans-serif'
@@ -71,13 +75,18 @@ class PlotlyScatter2DStaticExport(Tool):
         polar = getattr(self.viewer.state, 'using_polar', False)
         degrees = polar and self.viewer.state.using_degrees
 
+        # other projections
+        proj = self.viewer.state.plot_mode
+        proj_type = 'azimuthal equal area' if proj == 'lambert' else proj
+
         # set the aspect ratio of the axes, the tick label size, the axis label
         # sizes, and the axes limits
         layout_config = dict(
             margin=dict(r=50, l=50, b=50, t=50),  # noqa
             width=1200,
             height=1200*height/width,  # scale axis correctly
-            plot_bgcolor='white',
+            paper_bgcolor=settings.BACKGROUND_COLOR,
+            plot_bgcolor=settings.BACKGROUND_COLOR
         )
 
         if polar:
@@ -95,7 +104,9 @@ class PlotlyScatter2DStaticExport(Tool):
                     family=DEFAULT_FONT,
                     size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
                         0].get_fontsize(),
-                    color='black')
+                    color=settings.FOREGROUND_COLOR),
+                linecolor=settings.FOREGROUND_COLOR,
+                gridcolor=settings.FOREGROUND_COLOR
             )
             radial_axis = dict(
                 type='linear',
@@ -111,10 +122,14 @@ class PlotlyScatter2DStaticExport(Tool):
                     family=DEFAULT_FONT,
                     size=1.5*self.viewer.axes.yaxis.get_ticklabels()[
                         0].get_fontsize(),
-                    color='black')
+                    color=settings.FOREGROUND_COLOR),
+                linecolor=settings.FOREGROUND_COLOR,
+                gridcolor=settings.FOREGROUND_COLOR
             )
-            polar_layout = go.layout.Polar(angularaxis=angular_axis, radialaxis=radial_axis)
+            polar_layout = go.layout.Polar(angularaxis=angular_axis, radialaxis=radial_axis,
+                            bgcolor=settings.BACKGROUND_COLOR)
             layout_config.update(polar=polar_layout)
+            
         else:
             angle_unit = None
             x_axis = dict(
@@ -122,16 +137,22 @@ class PlotlyScatter2DStaticExport(Tool):
                 titlefont=dict(
                     family=DEFAULT_FONT,
                     size=2*self.viewer.axes.xaxis.get_label().get_size(),
-                    color='black'
+                    color=settings.FOREGROUND_COLOR
                 ),
                 showspikes=False,
-                zerolinecolor='rgb(128,128,128)',
+                linecolor=settings.FOREGROUND_COLOR,
+                tickcolor=settings.FOREGROUND_COLOR,
+                zeroline=False,
+                mirror=True,
+                ticks='outside',
+                showline=True,
+                showgrid=False,
                 showticklabels=True,
                 tickfont=dict(
                     family=DEFAULT_FONT,
                     size=1.5*self.viewer.axes.xaxis.get_ticklabels()[
                         0].get_fontsize(),
-                    color='black'),
+                    color=settings.FOREGROUND_COLOR),
                 range=[self.viewer.state.x_min, self.viewer.state.x_max]
             )
             y_axis = dict(
@@ -139,16 +160,22 @@ class PlotlyScatter2DStaticExport(Tool):
                 titlefont=dict(
                     family=DEFAULT_FONT,
                     size=2*self.viewer.axes.yaxis.get_label().get_size(),
-                    color='black'),
+                    color=settings.FOREGROUND_COLOR),
+                showgrid=False,
                 showspikes=False,
-                gridcolor='rgb(220,220,220)',
+                linecolor=settings.FOREGROUND_COLOR,
+                tickcolor=settings.FOREGROUND_COLOR,
+                zeroline=False,
+                mirror=True,
+                ticks='outside',
+                showline=True,
                 range=[self.viewer.state.y_min, self.viewer.state.y_max],
                 showticklabels=True,
                 tickfont=dict(
                     family=DEFAULT_FONT,
                     size=1.5*self.viewer.axes.yaxis.get_ticklabels()[
                         0].get_fontsize(),
-                    color='black'),
+                    color=settings.FOREGROUND_COLOR),
             )
             layout_config.update(xaxis=x_axis, yaxis=y_axis)
 
@@ -162,8 +189,8 @@ class PlotlyScatter2DStaticExport(Tool):
 
             if layer_state.visible and layer.enabled:
 
-                x = layer_state.layer[self.viewer.state.x_att]
-                y = layer_state.layer[self.viewer.state.y_att]
+                x = layer_state.layer[self.viewer.state.x_att].copy()
+                y = layer_state.layer[self.viewer.state.y_att].copy()
 
                 marker = {}
 
@@ -194,33 +221,136 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 # set all points to be the same size, with some arbitrary scaling
                 if layer_state.size_mode == 'Fixed':
-                    marker['size'] = layer_state.size
+                    marker['size'] = 2 * layer_state.size_scaling * layer_state.size
 
-                # scale size of points by some attribute
+                # scale size of points by set size scaling
                 else:
                     s = ensure_numerical(layer_state.layer[layer_state.size_att].ravel())
-                    marker['size'] = 25 * (s - layer_state.size_vmin) / (
-                        layer_state.size_vmax - layer_state.size_vmin)
-                    marker['sizemin'] = 1
-                    marker['size'][np.isnan(marker['size'])] = 0
-                    marker['size'][marker['size'] < 0] = 0
+                    s = ((s - layer_state.size_vmin) /
+                                 (layer_state.size_vmax - layer_state.size_vmin))
+                    # The following ensures that the sizes are in the
+                    # range 3 to 30 before the final size scaling.
+                    np.clip(s, 0, 1, out=s)
+                    s *= 0.95
+                    s += 0.05
+                    s *= (30 * layer_state.size_scaling)
+                    marker['size'] = s
 
                 # set the opacity
                 marker['opacity'] = layer_state.alpha
 
-                # remove default white border around points
-                marker['line'] = dict(width=0)
+                # check whether or not to fill circles
+                
+                if not layer_state.fill:
+                    marker['color'] = 'rgba(0,0,0,0)'
+                    marker['line'] = dict(width=1, 
+                                          color=layer_state.color)
+
+                else:
+                    # remove default white border around points
+                    marker['line'] = dict(width=0)
+
+                # add vectors
+                if layer_state.vector_visible:
+                    proceed = warn('Arrows may look different', 'Plotly and Matlotlib vector graphics differ and your graph may look different when exported. Do you want to proceed?',
+                    default='Cancel', setting='SHOW_WARN_PROFILE_DUPLICATE')
+                    if not proceed:
+                        return
+                    vx = layer_state.layer[layer_state.vx_att]
+                    vy = layer_state.layer[layer_state.vy_att]
+                    vector_info = dict(scale = .1 * layer_state.vector_scaling,
+                                        arrow_scale=.3, line_width=3,
+                                        showlegend=False, hoverinfo='skip')
+                    if layer_state.cmap_mode == 'Fixed':
+                        fig = ff.create_quiver(x, y, vx, vy, **vector_info)
+                        fig.update_traces(marker=dict(color=layer_state.color))
+                    else:
+                        # start with the first quiver to add the rest
+                        fig = ff.create_quiver([x[0]], [y[0]], [vx[0]], [vy[0]],
+                                        **vector_info, line_color=marker['color'][0])
+                        for i in range(1, len(marker['color'])):
+                            fig1 = ff.create_quiver([x[i]], [y[i]], [vx[i]], [vy[i]],
+                                                    **vector_info,
+                                                    line_color=marker['color'][i])
+                            fig.add_traces(data=fig1.data)
+                    fig.update_layout(layout)
+
 
                 # add line properties
 
                 line = {}
 
                 if layer_state.line_visible:
-                    mode = 'lines+markers'
-                    line['dash'] = layer_state.linestyle
+                    # convert linestyle names from glue values to plotly values
+                    ls_dict = {'solid':'solid', 'dotted':'dot', 'dashed':'dash', 'dashdot':'dashdot'}
+                    line['dash'] = ls_dict[layer_state.linestyle]
                     line['width'] = layer_state.linewidth
+
+                    if layer_state.cmap_mode == 'Fixed':
+                        mode = 'lines+markers'
+                        line['color'] = layer_state.color
+                    else:
+                        # set mode to markers and plot the colored line over it
+                        mode = 'markers'
+                        lc = plot_colored_line(self.viewer.axes, x, y, rgb_str)
+                        segments = lc.get_segments()
+                        # generate list of indices to parse colors over
+                        indices = np.repeat(range(len(x)), 2)
+                        indices = indices[1:len(x) * 2 - 1]
+                        for i in range(len(segments)):
+                            fig.add_trace(go.Scatter(
+                                        x=[segments[i][0][0], segments[i][1][0]], 
+                                        y=[segments[i][0][1], segments[i][1][1]], 
+                                        mode='lines', 
+                                        line=dict(
+                                            dash=ls_dict[layer_state.linestyle],
+                                            width=layer_state.linewidth,
+                                            color=rgb_str[indices[i]]),
+                                        showlegend=False,
+                                        hoverinfo='skip')
+                            )       
                 else:
                     mode = 'markers'
+
+                # add error bars
+                 
+                xerr = {}
+                if layer_state.xerr_visible:
+                    xerr['type'] = 'data'
+                    xerr['array'] = ensure_numerical(layer_state.layer[layer_state.xerr_att].ravel())
+                    xerr['visible'] = True
+                    # add points with error bars here if color mode is linear
+                    if layer_state.cmap_mode == 'Linear':
+                        for i, bar in enumerate(xerr['array']):
+                            fig.add_trace(go.Scatter(
+                                        x=[x[i]], 
+                                        y=[y[i]], 
+                                        mode='markers', 
+                                        error_x=dict(
+                                            type='data', color=marker['color'][i], 
+                                            array=[bar], visible=True),
+                                        marker=dict(color=marker['color'][i]),
+                                        showlegend=False)
+                                )
+                
+                yerr = {}
+                if layer_state.yerr_visible:
+                    yerr['type'] = 'data'
+                    yerr['array'] = ensure_numerical(layer_state.layer[layer_state.yerr_att].ravel())
+                    yerr['visible'] = True
+                    # add points with error bars here if color mode is linear
+                    if layer_state.cmap_mode == 'Linear':
+                        for i, bar in enumerate(yerr['array']):
+                            fig.add_trace(go.Scatter(
+                                        x=[x[i]], 
+                                        y=[y[i]], 
+                                        mode='markers', 
+                                        error_y=dict(
+                                            type='data', color=marker['color'][i], 
+                                            array=[bar], visible=True),
+                                        marker=dict(color=marker['color'][i]),
+                                        showlegend=False)
+                                )
 
                 # add hover info to layer
 
@@ -250,8 +380,23 @@ class PlotlyScatter2DStaticExport(Tool):
                 if polar:
                     scatter_info.update(theta=x, r=y, thetaunit=angle_unit)
                     fig.add_scatterpolar(**scatter_info)
-                else:
+                elif proj == 'rectilinear':
                     scatter_info.update(x=x, y=y)
+                    # add error bars here if the color mode was fixed
+                    if layer_state.cmap_mode == 'Fixed':
+                        scatter_info.update(error_x=xerr, error_y=yerr)
                     fig.add_scatter(**scatter_info)
+                else:
+                    if not degrees:
+                        x = x * 180 / np.pi
+                        y = y * 180 / np.pi
+                    fig.add_traces(data=go.Scattergeo(lon=x, lat=y))
+                    fig.update_geos(projection_type=proj_type, 
+                        showland=False, showcoastlines=False, showlakes=False,
+                        lataxis_showgrid=False, lonaxis_showgrid=False,
+                        bgcolor=settings.BACKGROUND_COLOR,
+                        framecolor=settings.FOREGROUND_COLOR)
+                    fig.update_traces(**scatter_info)
+
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -211,6 +211,17 @@ class PlotlyScatter2DStaticExport(Tool):
                 # remove default white border around points
                 marker['line'] = dict(width=0)
 
+                # add line properties
+
+                line = {}
+
+                if layer_state.line_visible:
+                    mode = 'lines+markers'
+                    line['dash'] = layer_state.linestyle
+                    line['width'] = layer_state.linewidth
+                else:
+                    mode = 'markers'
+
                 # add hover info to layer
 
                 if np.sum(dialog.checked_dictionary[layer_state.layer.label]) == 0:
@@ -229,8 +240,9 @@ class PlotlyScatter2DStaticExport(Tool):
 
                 # add layer to axesdict(
                 scatter_info = dict(
-                    mode='markers',
+                    mode=mode,
                     marker=marker,
+                    line=line,
                     hoverinfo=hoverinfo,
                     hovertext=hovertext,
                     name=layer_state.layer.label

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -263,7 +263,11 @@ class PlotlyScatter2DStaticExport(Tool):
                                         showlegend=False, hoverinfo='skip')
                     if layer_state.cmap_mode == 'Fixed':
                         fig = ff.create_quiver(x, y, vx, vy, **vector_info)
-                        fig.update_traces(marker=dict(color=layer_state.color))
+                        if layer_state.color != '0.35':
+                            fig.update_traces(marker=dict(color=layer_state.color))
+                        else:
+                            fig.update_traces(marker=dict(color='gray'))
+                        
                     else:
                         # start with the first quiver to add the rest
                         fig = ff.create_quiver([x[0]], [y[0]], [vx[0]], [vy[0]],
@@ -287,8 +291,11 @@ class PlotlyScatter2DStaticExport(Tool):
                     line['width'] = layer_state.linewidth
 
                     if layer_state.cmap_mode == 'Fixed':
+                        if layer_state.color != '0.35':
+                            marker['color'] = layer_state.color
+                        else:
+                            marker['color'] = 'gray'
                         mode = 'lines+markers'
-                        line['color'] = layer_state.color
                     else:
                         # set mode to markers and plot the colored line over it
                         mode = 'markers'

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -278,18 +278,14 @@ class PlotlyScatter2DStaticExport(Tool):
                         vy = r * np.sin(theta)
 
                     vmax = np.nanmax(np.hypot(vx, vy))
-                    vxmax = abs(np.nanmax(vx))
-                    vymax = abs(np.nanmax(vy))
-                    # corner = np.nanmax(x), np.nanmax(y))
                     diag = np.hypot(self.viewer.state.x_max-self.viewer.state.x_min,
                                       self.viewer.state.y_max-self.viewer.state.y_min)
-                    scale = 0.1 * (layer_state.vector_scaling) * (diag / vmax)
-                    angle = pi / 9 if layer_state.vector_arrowhead else 0
+                    scale = 0.05 * (layer_state.vector_scaling) * (diag / vmax) * (width / self.viewer.width())
                     xrange = abs(self.viewer.state.x_max-self.viewer.state.x_min)
                     yrange = abs(self.viewer.state.y_max-self.viewer.state.y_min)
                     minfrac = min(xrange / diag, yrange / diag)
-                    arrow_scale = 0.3 * minfrac if layer_state.vector_arrowhead else 0
-                    print(arrow_scale)
+                    arrow_scale = 0.2
+                    angle = pi * minfrac / 3 if layer_state.vector_arrowhead else 0
                     vector_info = dict(scale=scale,
                                        angle=angle,
                                        name='quiver',


### PR DESCRIPTION
This PR contains some updates from @victoriaono and myself to the 2D scatter exporter. These updates include:
* Add support for lines
* Respect current foreground/background color settings
* Add support for vectors and error bars in rectilinear mode
* Improve point size scaling
* Use plotly's `Scattergeo` for full-sphere projections

The exported vectors don't match up 100% to what's in glue - I tried to match the glue/matplotlib scaling as closely as I could. The arrowheads on vectors behave a bit differently as well - it doesn't seem to be possible to get the arrowheads to be symmetric about the vector like the matplotlib ones are.

Vectors and errors bars are only implemented for the rectilinear projection - other projections can be tackled in a future PR.