### PR TITLE
Share functionality between web and HTML 2D scatter exporters

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -13,6 +13,7 @@ PLOTLY_ERROR_MESSAGE = "An error occurred during the export to Plotly:"
 
 def setup():
 
+    from . import common
     from . import html_exporters  # noqa
     from .web.qt import setup
     setup()

--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -13,7 +13,7 @@ PLOTLY_ERROR_MESSAGE = "An error occurred during the export to Plotly:"
 
 def setup():
 
-    from . import common
+    from . import common  # noqa
     from . import html_exporters  # noqa
     from .web.qt import setup
     setup()

--- a/glue_plotly/common/__init__.py
+++ b/glue_plotly/common/__init__.py
@@ -1,0 +1,1 @@
+from common import *

--- a/glue_plotly/common/__init__.py
+++ b/glue_plotly/common/__init__.py
@@ -1,1 +1,2 @@
-from common import *
+from .common import *
+from . import scatter2d

--- a/glue_plotly/common/__init__.py
+++ b/glue_plotly/common/__init__.py
@@ -1,2 +1,2 @@
-from .common import *
-from . import scatter2d
+from .common import *  # noqa
+from . import scatter2d  # noqa

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -25,7 +25,7 @@ def base_layout_config(viewer, **kwargs):
     return config
 
 
-def cartesian_axis(viewer, axis='x'):
+def rectilinear_axis(viewer, axis='x'):
     title = getattr(viewer.axes, f'get_{axis}label')()
     ax = getattr(viewer.axes, f'{axis}axis')
     range = [getattr(viewer.state, f'{axis}_min'), getattr(viewer.state, f'{axis}_max')]
@@ -80,7 +80,7 @@ def fixed_color(layer):
     return layer_color
 
 
-def rgb_colors(layer):
+def rgb_colors(layer, mask=None):
     layer_state = layer.state
     if layer_state.cmap_vmin > layer_state.cmap_vmax:
         cmap = layer_state.cmap.reversed()
@@ -91,15 +91,18 @@ def rgb_colors(layer):
         norm = Normalize(
             vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
 
-    rgba_list = [
-        cmap(norm(point)) for point in layer_state.layer[layer_state.cmap_att].copy()]
+    color_values = layer_state.layer[layer_state.cmap_att].copy()
+    rgba_list = np.array([
+        cmap(norm(point)) for point in color_values])
+    if mask is not None:
+        rgba_list = rgba_list[mask]
     rgb_strs = [r'{}'.format(rgb2hex(
         (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
     return rgb_strs
 
 
-def color_info(layer):
+def color_info(layer, mask=None):
     if layer.state.cmap_mode == "Fixed":
         return fixed_color(layer)
     else:
-        return rgb_colors(layer)
+        return rgb_colors(layer, mask)

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -18,7 +18,7 @@ def layers_to_export(viewer):
 # Count the number of unique Data objects (either directly or as parents of subsets)
 # used in the set of layers
 def data_count(layers):
-    data = set(d if isinstance(d := layer.layer, BaseData) else d.data for layer in layers)
+    data = set(layer.layer if isinstance(layer.layer, BaseData) else layer.layer.data for layer in layers)
     return len(data)
 
 

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from glue.config import settings
+
+DEFAULT_FONT = 'Arial, sans-serif'
+
+
+def base_layout_config(viewer, **kwargs):
+    # set the aspect ratio of the axes, the tick label size, the axis label
+    # sizes, and the axes limits
+    width, height = viewer.figure.get_size_inches() * viewer.figure.dpi
+
+    config = dict(
+        margin=dict(r=50, l=50, b=50, t=50),  # noqa
+        width=1200,
+        height=1200 * height / width,  # scale axis correctly
+        paper_bgcolor=settings.BACKGROUND_COLOR,
+        plot_bgcolor=settings.BACKGROUND_COLOR
+    )
+    config.update(kwargs)
+    return config
+
+
+def cartesian_axis(viewer, axis='x'):
+    x_axis = axis == 'x'
+    title = viewer.axes.get_xlabel() if x_axis else viewer.axes.get_ylabel()
+    ax = viewer.axes.xaxis if x_axis else viewer.axes.yaxis
+    range = [viewer.state.x_min, viewer.state.x_max] if x_axis \
+        else [viewer.state.y_min, viewer.state.y_max]
+    log = viewer.state.x_log if x_axis else viewer.state.y_log
+    if log:
+        range = [np.log10(b) for b in range]
+    axis_dict = dict(
+        title=title,
+        titlefont=dict(
+            family=DEFAULT_FONT,
+            size=2 * ax.get_label().get_size(),
+            color=settings.FOREGROUND_COLOR
+        ),
+        showspikes=False,
+        linecolor=settings.FOREGROUND_COLOR,
+        tickcolor=settings.FOREGROUND_COLOR,
+        zeroline=False,
+        mirror=True,
+        ticks='outside',
+        showline=True,
+        showgrid=False,
+        showticklabels=True,
+        tickfont=dict(
+            family=DEFAULT_FONT,
+            size=1.5 * ax.get_ticklabels()[
+                0].get_fontsize(),
+            color=settings.FOREGROUND_COLOR),
+        range=range,
+        type='log' if log else 'linear',
+        rangemode='normal',
+    )
+    if log:
+        axis_dict.update(dtick=1, minor_ticks='outside')
+    return axis_dict
+
+
+
+def sanitize(*arrays):
+    mask = np.ones(arrays[0].shape, dtype=bool)
+    for a in arrays:
+        try:
+            mask &= (~np.isnan(a))
+        except TypeError:  # non-numeric dtype
+            pass
+
+    return tuple(a[mask].ravel() for a in arrays)

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -1,14 +1,18 @@
+from matplotlib.colors import Normalize, rgb2hex
 import numpy as np
 
 from glue.config import settings
 
 DEFAULT_FONT = 'Arial, sans-serif'
 
+def dimensions(viewer):
+    return viewer.figure.get_size_inches() * viewer.figure.dpi
+
 
 def base_layout_config(viewer, **kwargs):
     # set the aspect ratio of the axes, the tick label size, the axis label
     # sizes, and the axes limits
-    width, height = viewer.figure.get_size_inches() * viewer.figure.dpi
+    width, height = dimensions(viewer)
 
     config = dict(
         margin=dict(r=50, l=50, b=50, t=50),  # noqa
@@ -22,12 +26,10 @@ def base_layout_config(viewer, **kwargs):
 
 
 def cartesian_axis(viewer, axis='x'):
-    x_axis = axis == 'x'
-    title = viewer.axes.get_xlabel() if x_axis else viewer.axes.get_ylabel()
-    ax = viewer.axes.xaxis if x_axis else viewer.axes.yaxis
-    range = [viewer.state.x_min, viewer.state.x_max] if x_axis \
-        else [viewer.state.y_min, viewer.state.y_max]
-    log = viewer.state.x_log if x_axis else viewer.state.y_log
+    title = getattr(viewer.axes, f'get_{axis}label')()
+    ax = getattr(viewer.axes, f'{axis}axis')
+    range = [getattr(viewer.state, f'{axis}_min'), getattr(viewer.state, f'{axis}_max')]
+    log = getattr(viewer.state, f'{axis}_log')
     if log:
         range = [np.log10(b) for b in range]
     axis_dict = dict(
@@ -60,7 +62,6 @@ def cartesian_axis(viewer, axis='x'):
     return axis_dict
 
 
-
 def sanitize(*arrays):
     mask = np.ones(arrays[0].shape, dtype=bool)
     for a in arrays:
@@ -70,3 +71,35 @@ def sanitize(*arrays):
             pass
 
     return tuple(a[mask].ravel() for a in arrays)
+
+
+def fixed_color(layer):
+    layer_color = layer.state.color
+    if layer_color == '0.35':
+        layer_color = 'gray'
+    return layer_color
+
+
+def rgb_colors(layer):
+    layer_state = layer.state
+    if layer_state.cmap_vmin > layer_state.cmap_vmax:
+        cmap = layer_state.cmap.reversed()
+        norm = Normalize(
+            vmin=layer_state.cmap_vmax, vmax=layer_state.cmap_vmin)
+    else:
+        cmap = layer_state.cmap
+        norm = Normalize(
+            vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
+
+    rgba_list = [
+        cmap(norm(point)) for point in layer_state.layer[layer_state.cmap_att].copy()]
+    rgb_strs = [r'{}'.format(rgb2hex(
+        (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
+    return rgb_strs
+
+
+def color_info(layer):
+    if layer.state.cmap_mode == "Fixed":
+        return fixed_color(layer)
+    else:
+        return rgb_colors(layer)

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -70,7 +70,7 @@ def sanitize(*arrays):
         except TypeError:  # non-numeric dtype
             pass
 
-    return tuple(a[mask].ravel() for a in arrays)
+    return mask, tuple(a[mask].ravel() for a in arrays)
 
 
 def fixed_color(layer):

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -2,12 +2,24 @@ from matplotlib.colors import Normalize
 import numpy as np
 
 from glue.config import settings
+from glue.core import BaseData
 
 DEFAULT_FONT = 'Arial, sans-serif'
 
 
 def dimensions(viewer):
     return viewer.figure.get_size_inches() * viewer.figure.dpi
+
+
+def layers_to_export(viewer):
+    return list(filter(lambda artist: artist.enabled and artist.visible, viewer.layers))
+
+
+# Count the number of unique Data objects (either directly or as parents of subsets)
+# used in the set of layers
+def data_count(layers):
+    data = set(d if isinstance(d := layer.layer, BaseData) else d.data for layer in layers)
+    return len(data)
 
 
 def base_layout_config(viewer, **kwargs):

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -1,9 +1,10 @@
-from matplotlib.colors import Normalize, rgb2hex
+from matplotlib.colors import Normalize
 import numpy as np
 
 from glue.config import settings
 
 DEFAULT_FONT = 'Arial, sans-serif'
+
 
 def dimensions(viewer):
     return viewer.figure.get_size_inches() * viewer.figure.dpi
@@ -92,13 +93,13 @@ def rgb_colors(layer, mask=None):
             vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
 
     color_values = layer_state.layer[layer_state.cmap_att].copy()
+    if mask is not None:
+        color_values = color_values[mask]
     rgba_list = np.array([
         cmap(norm(point)) for point in color_values])
-    if mask is not None:
-        rgba_list = rgba_list[mask]
-    rgb_strs = [r'{}'.format(rgb2hex(
-        (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
-    return rgb_strs
+    rgba_list = [[int(256 * t) for t in rgba] for rgba in rgba_list]
+    rgba_strs = [f'rgba({r},{g},{b},{a})' for r, g, b, a in rgba_list]
+    return rgba_strs
 
 
 def color_info(layer, mask=None):

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -5,6 +5,7 @@ import plotly.graph_objs as go
 import plotly.figure_factory as ff
 
 from glue.config import settings
+from glue.core import BaseData
 from glue.utils import ensure_numerical
 from glue.viewers.scatter.layer_artist import plot_colored_line
 
@@ -282,6 +283,10 @@ def traces_for_layer(viewer, layer, hover_data=None):
                                     .format(layer_state.layer.components[i].label,
                                             hover_values[k]))
 
+    name = layer.layer.label
+    if not isinstance(layer.layer, BaseData):
+        name += " ({0})".format(layer.layer.data.label)
+
     # The <extra></extra> removes 'trace <#>' from tooltip
     scatter_info = dict(
         mode=mode,
@@ -289,7 +294,7 @@ def traces_for_layer(viewer, layer, hover_data=None):
         line=line,
         hoverinfo=hoverinfo,
         hovertext=hovertext,
-        name=layer_state.layer.label,
+        name=name,
         legendgroup=legend_group
     )
 

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -1,0 +1,210 @@
+import matplotlib.colors as colors
+from matplotlib.colors import Normalize
+import numpy as np
+import plotly.graph_objs as go
+
+from glue.config import settings
+from glue.utils import ensure_numerical
+from glue.viewers.scatter.layer_artist import plot_colored_line
+
+from glue_plotly.common import DEFAULT_FONT, base_layout_config, cartesian_axis
+
+
+def angular_axis(viewer):
+    degrees = viewer.state.using_degrees
+    angle_unit = 'degrees' if degrees else 'radians'
+    theta_prefix = ''
+    if viewer.state.x_axislabel:
+        theta_prefix = '{0}='.format(viewer.state.x_axislabel)
+
+    return dict(
+        type='linear',
+        thetaunit=angle_unit,
+        showticklabels=True,
+        showtickprefix='first',
+        tickprefix=theta_prefix,
+        tickfont=dict(
+            family=DEFAULT_FONT,
+            size=1.5 * viewer.axes.xaxis.get_ticklabels()[
+                0].get_fontsize(),
+            color=settings.FOREGROUND_COLOR),
+        linecolor=settings.FOREGROUND_COLOR,
+        gridcolor=settings.FOREGROUND_COLOR
+    )
+
+
+def radial_axis(viewer):
+    return dict(
+        type='linear',
+        range=[viewer.state.y_min, viewer.state.y_max],
+        showticklabels=True,
+        tickmode='array',
+        tickvals=viewer.axes.yaxis.get_majorticklocs(),
+        ticktext=['<i>{0}</i>'.format(t.get_text()) for t in viewer.axes.yaxis.get_majorticklabels()],
+        angle=22.5,
+        tickangle=22.5,
+        showline=False,
+        tickfont=dict(
+            family=DEFAULT_FONT,
+            size=1.5 * viewer.axes.yaxis.get_ticklabels()[
+                0].get_fontsize(),
+            color=settings.FOREGROUND_COLOR),
+        linecolor=settings.FOREGROUND_COLOR,
+        gridcolor=settings.FOREGROUND_COLOR
+    )
+
+
+def cartesian_layout_config(viewer):
+    layout_config = base_layout_config(viewer)
+    x_axis = cartesian_axis(viewer, 'x')
+    y_axis = cartesian_axis(viewer, 'y')
+    layout_config.update(xaxis=x_axis, yaxis=y_axis)
+    return layout_config
+
+
+def polar_layout_config(viewer):
+    layout_config = base_layout_config(viewer)
+    theta_axis = angular_axis(viewer)
+    r_axis = radial_axis(viewer)
+    polar = go.layout.Polar(angularaxis=theta_axis, radialaxis=r_axis,
+                            bgcolor=settings.BACKGROUND_COLOR)
+    layout_config.update(polar=polar)
+    return layout_config
+
+
+def cartesian_error_bars(layer, marker, x, y, axis='x'):
+    err = {}
+    traces = []
+    x_axis = axis == 'x'
+    err_att = layer.state.xerr_att if x_axis else layer.state.yerr_att
+    err['type'] = 'data'
+    err['array'] = ensure_numerical(layer.state.layer[err_att].ravel())
+    err['visible'] = True
+
+    # add points with error bars here if color mode is linear
+    if layer.state.cmap_mode == 'Linear':
+        for i, bar in enumerate(err['array']):
+            traces.append(go.Scatter(
+                x=[x[i]],
+                y=[y[i]],
+                mode='markers',
+                error_x=dict(
+                    type='data', color=marker['color'][i],
+                    array=[bar], visible=True),
+                marker=dict(color=marker['color'][i]),
+                showlegend=False)
+            )
+
+    return err, traces
+
+
+def traces_for_layer(viewer, layer):
+    traces = []
+
+    layer_state = layer.state
+
+    x = layer_state.layer[viewer.state.x_att].copy()
+    y = layer_state.layer[viewer.state.y_att].copy()
+
+    rectilinear = getattr(viewer.state, 'using_rectilinear', True)
+
+    marker = {}
+
+    layer_color = layer_state.color
+    if layer_color == '0.35':
+        layer_color = 'gray'
+
+    # set all points to be the same color
+    if layer_state.cmap_mode == 'Fixed':
+        marker['color'] = layer_color
+
+    # color by some attribute
+    else:
+        if layer_state.cmap_vmin > layer_state.cmap_vmax:
+            cmap = layer_state.cmap.reversed()
+            norm = Normalize(
+                vmin=layer_state.cmap_vmax, vmax=layer_state.cmap_vmin)
+        else:
+            cmap = layer_state.cmap
+            norm = Normalize(
+                vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
+
+        # most matplotlib colormaps aren't recognized by plotly, so we convert manually to a hex code
+        rgba_list = [
+            cmap(norm(point)) for point in layer_state.layer[layer_state.cmap_att].copy()]
+        rgb_str = [r'{}'.format(colors.rgb2hex(
+            (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
+        marker['color'] = rgb_str
+
+    # set all points to be the same size, with some arbitrary scaling
+    if layer_state.size_mode == 'Fixed':
+        marker['size'] = 2 * layer_state.size_scaling * layer_state.size
+
+    # scale size of points by set size scaling
+    else:
+        s = ensure_numerical(layer_state.layer[layer_state.size_att].ravel())
+        s = ((s - layer_state.size_vmin) /
+             (layer_state.size_vmax - layer_state.size_vmin))
+        # The following ensures that the sizes are in the
+        # range 3 to 30 before the final size scaling.
+        np.clip(s, 0, 1, out=s)
+        s *= 0.95
+        s += 0.05
+        s *= (30 * layer_state.size_scaling)
+        marker['size'] = s
+
+    # set the opacity
+    marker['opacity'] = layer_state.alpha
+
+    # check whether to fill circles
+
+    if not layer_state.fill:
+        marker['color'] = 'rgba(0,0,0,0)'
+        marker['line'] = dict(width=1,
+                              color=layer_state.color)
+
+    else:
+        # remove default white border around points
+        marker['line'] = dict(width=0)
+
+    # add line properties
+
+    line = {}
+
+    if layer_state.line_visible:
+        # convert linestyle names from glue values to plotly values
+        ls_dict = {'solid': 'solid', 'dotted': 'dot', 'dashed': 'dash', 'dashdot': 'dashdot'}
+        line['dash'] = ls_dict[layer_state.linestyle]
+        line['width'] = layer_state.linewidth
+
+        if layer_state.cmap_mode == 'Fixed':
+            marker['color'] = layer_color
+            mode = 'lines+markers'
+        else:
+            # set mode to markers and plot the colored line over it
+            mode = 'markers'
+            lc = plot_colored_line(viewer.axes, x, y, rgb_str)
+            segments = lc.get_segments()
+            # generate list of indices to parse colors over
+            indices = np.repeat(range(len(x)), 2)
+            indices = indices[1:len(x) * 2 - 1]
+            for i in range(len(segments)):
+                traces.append(go.Scatter(
+                    x=[segments[i][0][0], segments[i][1][0]],
+                    y=[segments[i][0][1], segments[i][1][1]],
+                    mode='lines',
+                    line=dict(
+                        dash=ls_dict[layer_state.linestyle],
+                        width=layer_state.linewidth,
+                        color=rgb_str[indices[i]]),
+                    showlegend=False,
+                    hoverinfo='skip')
+                )
+    else:
+        mode = 'markers'
+
+
+    if rectilinear:
+        if layer_state.xerr_visible:
+            xerr, xerr_traces = cartesian_error_bars(layer, marker, x, y, 'x')
+        yerr, yerr_traces = cartesian_error_bars(layer, marker, x, y, 'y')

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -204,7 +204,7 @@ def rectilinear_2d_vectors(viewer, layer, marker, mask, x, y, legend_group=None)
     return list(fig.data)
 
 
-def traces_for_layer(viewer, layer, hover_data=None):
+def traces_for_layer(viewer, layer, hover_data=None, add_data_label=True):
     traces = []
     if hover_data is None:
         hover_data = []
@@ -284,7 +284,7 @@ def traces_for_layer(viewer, layer, hover_data=None):
                                             hover_values[k]))
 
     name = layer.layer.label
-    if not isinstance(layer.layer, BaseData):
+    if add_data_label and not isinstance(layer.layer, BaseData):
         name += " ({0})".format(layer.layer.data.label)
 
     # The <extra></extra> removes 'trace <#>' from tooltip

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -7,7 +7,7 @@ from glue.utils import ensure_numerical
 from glue.viewers.scatter.layer_artist import plot_colored_line
 
 from .common import DEFAULT_FONT, base_layout_config,\
-    cartesian_axis, color_info, dimensions, sanitize
+    rectilinear_axis, color_info, dimensions, sanitize
 
 LINESTYLES = {'solid': 'solid', 'dotted': 'dot', 'dashed': 'dash', 'dashdot': 'dashdot'}
 
@@ -62,8 +62,8 @@ def radial_axis(viewer):
 
 def rectilinear_layout_config(viewer):
     layout_config = base_layout_config(viewer)
-    x_axis = cartesian_axis(viewer, 'x')
-    y_axis = cartesian_axis(viewer, 'y')
+    x_axis = rectilinear_axis(viewer, 'x')
+    y_axis = rectilinear_axis(viewer, 'y')
     layout_config.update(xaxis=x_axis, yaxis=y_axis)
     return layout_config
 
@@ -131,11 +131,13 @@ def rectilinear_error_bars(layer, marker, mask, x, y, axis):
                 y=[y[i]],
                 mode='markers',
                 marker=dict(color=marker['color'][i]),
-                showlegend=False
+                showlegend=False,
+                hoverinfo='skip',
+                hovertext=None
             )
             scatter_info[f'error_{axis}'] = dict(
                 type='data', color=marker['color'][i],
-                array=[bar], visible=True),
+                array=[bar], visible=True)
             traces.append(go.Scatter(**scatter_info))
 
     return err, traces
@@ -209,7 +211,7 @@ def traces_for_layer(viewer, layer, hover_data=None):
 
     rectilinear = getattr(viewer.state, 'using_rectilinear', True)
 
-    marker = dict(color=color_info(layer),
+    marker = dict(color=color_info(layer, mask),
                   opacity=layer_state.alpha)
 
     # set all points to be the same size, with some arbitrary scaling
@@ -273,6 +275,7 @@ def traces_for_layer(viewer, layer, hover_data=None):
                                     .format(layer_state.layer.components[i].label,
                                             hover_values[k]))
 
+    # The <extra></extra> removes 'trace <#>' from tooltip
     scatter_info = dict(
         mode=mode,
         marker=marker,

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -269,7 +269,7 @@ def traces_for_layer(viewer, layer, hover_data=None):
         hovertext = ["" for _ in range((layer_state.layer.shape[0]))]
         for i in range(0, len(layer_state.layer.components)):
             if hover_data[i]:
-                hover_values = layer_state.layer[layer_state.layer.components[i].label]
+                hover_values = layer_state.layer[layer_state.layer.components[i].label][mask]
                 for k in range(0, len(hover_values)):
                     hovertext[k] = (hovertext[k] + "{}: {} <br>"
                                     .format(layer_state.layer.components[i].label,

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -60,7 +60,7 @@ def radial_axis(viewer):
     )
 
 
-def cartesian_layout_config(viewer):
+def rectilinear_layout_config(viewer):
     layout_config = base_layout_config(viewer)
     x_axis = cartesian_axis(viewer, 'x')
     y_axis = cartesian_axis(viewer, 'y')
@@ -78,7 +78,7 @@ def polar_layout_config(viewer):
     return layout_config
 
 
-def cartesian_lines(viewer, layer, marker, x, y, ):
+def rectilinear_lines(viewer, layer, marker, x, y, ):
     layer_state = layer.state
 
     line = dict(
@@ -115,7 +115,7 @@ def cartesian_lines(viewer, layer, marker, x, y, ):
     return line, mode, traces
 
 
-def cartesian_error_bars(layer, marker, x, y, axis='x'):
+def rectilinear_error_bars(layer, marker, x, y, axis='x'):
     err = {}
     traces = []
     err_att = getattr(layer.state, f'{axis}err_att')
@@ -151,7 +151,7 @@ def _adjusted_vector_points(origin, scale, x, y, vx, vy):
         return x - vx, y - vy
 
 
-def cartesian_2d_vectors(viewer, layer, marker, x, y):
+def rectilinear_2d_vectors(viewer, layer, marker, x, y):
     width, _ = dimensions(viewer)
     layer_state = layer.state
     vx = layer_state.layer[layer_state.vx_att]
@@ -240,22 +240,22 @@ def traces_for_layer(viewer, layer, hover_data=None):
 
     # add vectors
     if rectilinear and layer.state.vector_visible and layer.state.vector_scaling > 0.1:
-        vec_traces = cartesian_2d_vectors(viewer, layer, marker, x, y)
+        vec_traces = rectilinear_2d_vectors(viewer, layer, marker, x, y)
         traces += vec_traces
 
     # add line properties
     mode = "markers"
     line = {}
     if layer_state.line_visible:
-        line, mode, line_traces = cartesian_lines(viewer, layer, marker, x, y)
+        line, mode, line_traces = rectilinear_lines(viewer, layer, marker, x, y)
         traces += line_traces
 
     if rectilinear:
         if layer_state.xerr_visible:
-            xerr, xerr_traces = cartesian_error_bars(layer, marker, x, y, 'x')
+            xerr, xerr_traces = rectilinear_error_bars(layer, marker, x, y, 'x')
             traces += xerr_traces
         if layer_state.yerr_visible:
-            yerr, yerr_traces = cartesian_error_bars(layer, marker, x, y, 'y')
+            yerr, yerr_traces = rectilinear_error_bars(layer, marker, x, y, 'y')
             traces += yerr_traces
 
     if np.sum(hover_data) == 0:

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -1,18 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from math import pi
 import numpy as np
-import matplotlib.colors as colors
-from matplotlib.colors import Normalize
 
 from qtpy import compat
 from qtpy.QtWidgets import QDialog
 
 from glue.config import viewer_tool, settings
 from glue.core import DataCollection, Data
-from glue.utils import ensure_numerical
 from glue.utils.qt import messagebox_on_error
-from glue.viewers.scatter.layer_artist import plot_colored_line
 
 from .. import save_hover
 
@@ -23,6 +18,7 @@ except ImportError:
 from glue.core.qt.dialogs import warn
 
 from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
+from glue_plotly.common import data_count, layers_to_export
 from glue_plotly.common.scatter2d import rectilinear_layout_config,\
     polar_layout_config, traces_for_layer
 
@@ -94,10 +90,14 @@ class PlotlyScatter2DStaticExport(Tool):
         layout = go.Layout(**layout_config)
         fig = go.Figure(layout=layout)
 
-        for layer in self.viewer.layers:
-            if layer.enabled and layer.visible:
-                traces = traces_for_layer(self.viewer, layer, checked_dictionary[layer.state.layer.label])
-                for trace in traces:
-                    fig.add_trace(trace)
+        layers = layers_to_export(self.viewer)
+        add_data_label = data_count(layers) > 1
+        for layer in layers:
+            traces = traces_for_layer(self.viewer,
+                                      layer,
+                                      hover_data=checked_dictionary[layer.state.layer.label],
+                                      add_data_label=add_data_label)
+            for trace in traces:
+                fig.add_trace(trace)
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -23,7 +23,7 @@ except ImportError:
 from glue.core.qt.dialogs import warn
 
 from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
-from glue_plotly.common.scatter2d import cartesian_layout_config,\
+from glue_plotly.common.scatter2d import rectilinear_layout_config,\
     polar_layout_config, traces_for_layer
 
 from plotly.offline import plot
@@ -78,7 +78,7 @@ class PlotlyScatter2DStaticExport(Tool):
         if polar:
             layout_config = polar_layout_config(self.viewer)
         else:
-            layout_config = cartesian_layout_config(self.viewer)
+            layout_config = rectilinear_layout_config(self.viewer)
 
         if rectilinear:
             need_vectors = any(layer.state.vector_visible and layer.state.vector_scaling > 0.1

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -23,11 +23,11 @@ except ImportError:
 from glue.core.qt.dialogs import warn
 
 from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
-from glue_plotly.common.scatter2d import cartesian_layout_config, polar_layout_config
+from glue_plotly.common.scatter2d import cartesian_layout_config,\
+    polar_layout_config, traces_for_layer
 
 from plotly.offline import plot
 import plotly.graph_objs as go
-import plotly.figure_factory as ff
 
 DEFAULT_FONT = 'Arial, sans-serif'
 
@@ -41,16 +41,6 @@ class PlotlyScatter2DStaticExport(Tool):
     tool_id = 'save:plotly2d'
     action_text = 'Save Plotly HTML page'
     tool_tip = 'Save Plotly HTML page'
-
-    def _adjusted_vector_points(self, origin, scale, x, y, vx, vy):
-        vx = scale * vx
-        vy = scale * vy
-        if origin == 'tail':
-            return x, y
-        elif origin == 'middle':
-            return x - 0.5 * vx, y - 0.5 * vy
-        else:  # tip
-            return x - vx, y - vy
 
     @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
     def activate(self):
@@ -82,263 +72,32 @@ class PlotlyScatter2DStaticExport(Tool):
         if not filename:
             return
 
-        width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
-
         rectilinear = getattr(self.viewer.state, 'using_rectilinear', True)
         polar = getattr(self.viewer.state, 'using_polar', False)
-        degrees = polar and self.viewer.state.using_degrees
-
-        # other projections
-        proj = self.viewer.state.plot_mode
-        proj_type = 'azimuthal equal area' if proj == 'lambert' else proj
 
         if polar:
             layout_config = polar_layout_config(self.viewer)
         else:
             layout_config = cartesian_layout_config(self.viewer)
 
-        layout = go.Layout(**layout_config)
+        if rectilinear:
+            need_vectors = any(layer.state.vector_visible and layer.state.vector_scaling > 0.1
+                               for layer in self.viewer.layers)
+            if need_vectors:
+                proceed = warn('Arrows may look different',
+                               'Plotly and Matlotlib vector graphics differ and your graph may look different '
+                               'when exported. Do you want to proceed?',
+                               default='Cancel', setting=SHOW_PLOTLY_VECTORS_2D_DIFFERENT)
+                if not proceed:
+                    return
 
+        layout = go.Layout(**layout_config)
         fig = go.Figure(layout=layout)
 
         for layer in self.viewer.layers:
-
-            layer_state = layer.state
-
-            if layer_state.visible and layer.enabled:
-
-                x = layer_state.layer[self.viewer.state.x_att].copy()
-                y = layer_state.layer[self.viewer.state.y_att].copy()
-
-                marker = {}
-
-                layer_color = layer_state.color
-                if layer_color == '0.35':
-                    layer_color = 'gray'
-
-                # set all points to be the same color
-                if layer_state.cmap_mode == 'Fixed':
-                    marker['color'] = layer_color
-
-                # color by some attribute
-                else:
-                    if layer_state.cmap_vmin > layer_state.cmap_vmax:
-                        cmap = layer_state.cmap.reversed()
-                        norm = Normalize(
-                            vmin=layer_state.cmap_vmax, vmax=layer_state.cmap_vmin)
-                    else:
-                        cmap = layer_state.cmap
-                        norm = Normalize(
-                            vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
-
-                    # most matplotlib colormaps aren't recognized by plotly, so we convert manually to a hex code
-                    rgba_list = [
-                        cmap(norm(point)) for point in layer_state.layer[layer_state.cmap_att].copy()]
-                    rgb_str = [r'{}'.format(colors.rgb2hex(
-                        (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
-                    marker['color'] = rgb_str
-
-                # set all points to be the same size, with some arbitrary scaling
-                if layer_state.size_mode == 'Fixed':
-                    marker['size'] = 2 * layer_state.size_scaling * layer_state.size
-
-                # scale size of points by set size scaling
-                else:
-                    s = ensure_numerical(layer_state.layer[layer_state.size_att].ravel())
-                    s = ((s - layer_state.size_vmin) /
-                         (layer_state.size_vmax - layer_state.size_vmin))
-                    # The following ensures that the sizes are in the
-                    # range 3 to 30 before the final size scaling.
-                    np.clip(s, 0, 1, out=s)
-                    s *= 0.95
-                    s += 0.05
-                    s *= (30 * layer_state.size_scaling)
-                    marker['size'] = s
-
-                # set the opacity
-                marker['opacity'] = layer_state.alpha
-
-                # check whether or not to fill circles
-
-                if not layer_state.fill:
-                    marker['color'] = 'rgba(0,0,0,0)'
-                    marker['line'] = dict(width=1,
-                                          color=layer_state.color)
-
-                else:
-                    # remove default white border around points
-                    marker['line'] = dict(width=0)
-
-                # add vectors
-                if layer_state.vector_visible and layer_state.vector_scaling > 0.1 and rectilinear:
-                    proceed = warn('Arrows may look different',
-                                   'Plotly and Matlotlib vector graphics differ and your graph may look different '
-                                   'when exported. Do you want to proceed?',
-                                   default='Cancel', setting=SHOW_PLOTLY_VECTORS_2D_DIFFERENT)
-                    if not proceed:
-                        return
-                    vx = layer_state.layer[layer_state.vx_att]
-                    vy = layer_state.layer[layer_state.vy_att]
-                    if layer_state.vector_mode == 'Polar':
-                        theta, r = vx, vy
-                        theta = np.radians(theta)
-                        vx = r * np.cos(theta)
-                        vy = r * np.sin(theta)
-
-                    vmax = np.nanmax(np.hypot(vx, vy))
-                    diag = np.hypot(self.viewer.state.x_max-self.viewer.state.x_min,
-                                    self.viewer.state.y_max-self.viewer.state.y_min)
-                    scale = 0.05 * (layer_state.vector_scaling) * (diag / vmax) * (width / self.viewer.width())
-                    xrange = abs(self.viewer.state.x_max-self.viewer.state.x_min)
-                    yrange = abs(self.viewer.state.y_max-self.viewer.state.y_min)
-                    minfrac = min(xrange / diag, yrange / diag)
-                    arrow_scale = 0.2
-                    angle = pi * minfrac / 3 if layer_state.vector_arrowhead else 0
-                    vector_info = dict(scale=scale,
-                                       angle=angle,
-                                       name='quiver',
-                                       arrow_scale=arrow_scale,
-                                       line=dict(width=5),
-                                       showlegend=False, hoverinfo='skip')
-                    x_vec, y_vec = self._adjusted_vector_points(layer_state.vector_origin, scale, x, y, vx, vy)
-                    if layer_state.cmap_mode == 'Fixed':
-                        fig = ff.create_quiver(x_vec, y_vec, vx, vy, **vector_info)
-                        fig.update_traces(marker=dict(color=layer_color))
-
-                    else:
-                        # start with the first quiver to add the rest
-                        fig = ff.create_quiver([x[0]], [y[0]], [vx[0]], [vy[0]],
-                                               **vector_info, line_color=marker['color'][0])
-                        for i in range(1, len(marker['color'])):
-                            fig1 = ff.create_quiver([x[i]], [y[i]], [vx[i]], [vy[i]],
-                                                    **vector_info,
-                                                    line_color=marker['color'][i])
-                            fig.add_traces(data=fig1.data)
-                    fig.update_layout(layout)
-
-                # add line properties
-
-                line = {}
-
-                if layer_state.line_visible:
-                    # convert linestyle names from glue values to plotly values
-                    ls_dict = {'solid': 'solid', 'dotted': 'dot', 'dashed': 'dash', 'dashdot': 'dashdot'}
-                    line['dash'] = ls_dict[layer_state.linestyle]
-                    line['width'] = layer_state.linewidth
-
-                    if layer_state.cmap_mode == 'Fixed':
-                        marker['color'] = layer_color
-                        mode = 'lines+markers'
-                    else:
-                        # set mode to markers and plot the colored line over it
-                        mode = 'markers'
-                        lc = plot_colored_line(self.viewer.axes, x, y, rgb_str)
-                        segments = lc.get_segments()
-                        # generate list of indices to parse colors over
-                        indices = np.repeat(range(len(x)), 2)
-                        indices = indices[1:len(x) * 2 - 1]
-                        for i in range(len(segments)):
-                            fig.add_trace(go.Scatter(
-                                x=[segments[i][0][0], segments[i][1][0]],
-                                y=[segments[i][0][1], segments[i][1][1]],
-                                mode='lines',
-                                line=dict(
-                                    dash=ls_dict[layer_state.linestyle],
-                                    width=layer_state.linewidth,
-                                    color=rgb_str[indices[i]]),
-                                showlegend=False,
-                                hoverinfo='skip')
-                            )
-                else:
-                    mode = 'markers'
-
-                # add error bars
-                if rectilinear:
-
-                    xerr = {}
-                    if layer_state.xerr_visible:
-                        xerr['type'] = 'data'
-                        xerr['array'] = ensure_numerical(layer_state.layer[layer_state.xerr_att].ravel())
-                        xerr['visible'] = True
-                        # add points with error bars here if color mode is linear
-                        if layer_state.cmap_mode == 'Linear':
-                            for i, bar in enumerate(xerr['array']):
-                                fig.add_trace(go.Scatter(
-                                    x=[x[i]],
-                                    y=[y[i]],
-                                    mode='markers',
-                                    error_x=dict(
-                                        type='data', color=marker['color'][i],
-                                        array=[bar], visible=True),
-                                    marker=dict(color=marker['color'][i]),
-                                    showlegend=False)
-                                )
-
-                    yerr = {}
-                    if layer_state.yerr_visible:
-                        yerr['type'] = 'data'
-                        yerr['array'] = ensure_numerical(layer_state.layer[layer_state.yerr_att].ravel())
-                        yerr['visible'] = True
-                        # add points with error bars here if color mode is linear
-                        if layer_state.cmap_mode == 'Linear':
-                            for i, bar in enumerate(yerr['array']):
-                                fig.add_trace(go.Scatter(
-                                    x=[x[i]],
-                                    y=[y[i]],
-                                    mode='markers',
-                                    error_y=dict(
-                                        type='data', color=marker['color'][i],
-                                        array=[bar], visible=True),
-                                    marker=dict(color=marker['color'][i]),
-                                    showlegend=False)
-                                )
-
-                # add hover info to layer
-
-                if np.sum(dialog.checked_dictionary[layer_state.layer.label]) == 0:
-                    hoverinfo = 'skip'
-                    hovertext = None
-                else:
-                    hoverinfo = 'text'
-                    hovertext = ["" for i in range((layer_state.layer.shape[0]))]
-                    for i in range(0, len(layer_state.layer.components)):
-                        if dialog.checked_dictionary[layer_state.layer.label][i]:
-                            hover_data = layer_state.layer[layer_state.layer.components[i].label]
-                            for k in range(0, len(hover_data)):
-                                hovertext[k] = (hovertext[k] + "{}: {} <br>"
-                                                .format(layer_state.layer.components[i].label,
-                                                        hover_data[k]))
-
-                # add layer to axesdict(
-                scatter_info = dict(
-                    mode=mode,
-                    marker=marker,
-                    line=line,
-                    hoverinfo=hoverinfo,
-                    hovertext=hovertext,
-                    name=layer_state.layer.label
-                )
-                if polar:
-                    scatter_info.update(theta=x, r=y, thetaunit='degrees' if degrees else 'radians')
-                    fig.add_scatterpolar(**scatter_info)
-                elif rectilinear:
-                    scatter_info.update(x=x, y=y)
-                    # add error bars here if the color mode was fixed
-                    if layer_state.cmap_mode == 'Fixed':
-                        scatter_info.update(error_x=xerr, error_y=yerr)
-                    fig.add_scatter(**scatter_info)
-                else:
-                    if not degrees:
-                        x = np.rad2deg(x)
-                        y = np.rad2deg(y)
-                    fig.add_traces(data=go.Scattergeo(lon=x, lat=y))
-                    fig.update_geos(projection_type=proj_type,
-                                    showland=False, showcoastlines=False, showlakes=False,
-                                    lataxis_showgrid=False, lonaxis_showgrid=False,
-                                    bgcolor=settings.BACKGROUND_COLOR,
-                                    framecolor=settings.FOREGROUND_COLOR)
-                    fig.update_traces(**scatter_info)
-
-            break
+            if layer.state.visible:
+                traces = traces_for_layer(self.viewer, layer, checked_dictionary[layer.state.layer.label])
+                for trace in traces:
+                    fig.add_trace(trace)
 
         plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/scatter2d.py
+++ b/glue_plotly/html_exporters/scatter2d.py
@@ -95,7 +95,7 @@ class PlotlyScatter2DStaticExport(Tool):
         fig = go.Figure(layout=layout)
 
         for layer in self.viewer.layers:
-            if layer.state.visible:
+            if layer.enabled and layer.visible:
                 traces = traces_for_layer(self.viewer, layer, checked_dictionary[layer.state.layer.label])
                 for trace in traces:
                     fig.add_trace(trace)

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -10,19 +10,10 @@ except ImportError:
 from glue.core.layout import Rectangle, snap_to_grid
 from glue.utils import categorical_ndarray
 
+from glue_plotly.common import cartesian_axis, sanitize
+
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
-
-
-def _sanitize(*arrs):
-    mask = np.ones(arrs[0].shape, dtype=bool)
-    for a in arrs:
-        try:
-            mask &= (~np.isnan(a))
-        except TypeError:  # non-numeric dtype
-            pass
-
-    return tuple(a[mask].ravel() for a in arrs)
 
 
 def _position_plots(viewers, layout):
@@ -87,22 +78,6 @@ def _grid_2x23(layout):
         layout[k].update(**v)
 
 
-def _axis(log=False, lo=0, hi=1, title='', categorical=False):
-    if log:
-        if lo < 0:
-            lo = 1e-3
-        if hi < 0:
-            hi = 1e-3
-        lo = np.log10(lo)
-        hi = np.log10(hi)
-
-    result = dict(type='log' if log else 'linear',
-                  rangemode='normal',
-                  range=[lo, hi], title=title)
-
-    return result
-
-
 def _fix_legend_duplicates(traces, layout):
     """Prevent repeat entries in the legend"""
     seen = set()
@@ -146,7 +121,7 @@ def export_scatter(viewer):
         if isinstance(y, categorical_ndarray):
             y = y.codes
 
-        x, y = _sanitize(x, y)
+        x, y = sanitize(x, y)
 
         trace = dict(x=x, y=y,
                      type='scatter',
@@ -156,10 +131,8 @@ def export_scatter(viewer):
 
         traces.append(trace)
 
-    xaxis = _axis(log=viewer.state.x_log, lo=viewer.state.x_min, hi=viewer.state.x_max,
-                  title=viewer.state.x_att.label, categorical=xcat)
-    yaxis = _axis(log=viewer.state.y_log, lo=viewer.state.y_min, hi=viewer.state.y_max,
-                  title=viewer.state.y_att.label, categorical=ycat)
+    xaxis = cartesian_axis(viewer, 'x')
+    yaxis = cartesian_axis(viewer, 'y')
 
     return traces, xaxis, yaxis
 
@@ -174,7 +147,7 @@ def export_histogram(viewer):
         artist.wait()
         layer = artist.layer
         edges, hist = artist.state.histogram
-        x, y = _sanitize(edges[:-1], hist)
+        x, y = sanitize(edges[:-1], hist)
         trace = dict(
             name=layer.label,
             type='bar',
@@ -184,15 +157,8 @@ def export_histogram(viewer):
         traces.append(trace)
         ymax = max(ymax, hist.max())
 
-    xlabel = att.label
-    xmin, xmax = viewer.state.x_min, viewer.state.x_max
-    if viewer.state.x_log:
-        xlabel = 'Log ' + xlabel
-        xmin = np.log10(xmin)
-        xmax = np.log10(xmax)
-    xaxis = _axis(lo=xmin, hi=xmax, title=xlabel)
-    yaxis = _axis(log=viewer.state.y_log, lo=0 if not viewer.state.y_log else 1e-3,
-                  hi=ymax * 1.05)
+    xaxis = cartesian_axis(viewer, 'x')
+    yaxis = cartesian_axis(viewer, 'y')
 
     return traces, xaxis, yaxis
 

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -103,10 +103,8 @@ def export_scatter(viewer):
     traces = []
 
     for layer in viewer.layers:
-        if not layer.visible:
-            continue
-
-        traces += scatter2d.traces_for_layer(viewer, layer)
+        if layer.enabled and layer.visible:
+            traces += scatter2d.traces_for_layer(viewer, layer)
 
     xaxis = cartesian_axis(viewer, 'x')
     yaxis = cartesian_axis(viewer, 'y')
@@ -116,10 +114,9 @@ def export_scatter(viewer):
 
 def export_histogram(viewer):
     traces = []
-    att = viewer.state.x_att
     ymax = 1e-3
     for artist in viewer.layers:
-        if not artist.visible:
+        if not (artist.enabled and artist.visible):
             continue
         artist.wait()
         layer = artist.layer

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -82,7 +82,7 @@ def _fix_legend_duplicates(traces, layout):
     """Prevent repeat entries in the legend"""
     seen = set()
     for t in traces:
-        key = (t.get('name'), t.get('marker', {}).get('color'))
+        key = (t.name, t.marker.symbol, t.marker.color)
         if key in seen:
             t['showlegend'] = False
         else:

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from glue.core.layout import Rectangle, snap_to_grid
 
-from glue_plotly.common import cartesian_axis, sanitize, scatter2d
+from glue_plotly.common import rectilinear_axis, sanitize, scatter2d
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -103,8 +103,8 @@ def export_scatter(viewer):
         if layer.enabled and layer.visible:
             traces += scatter2d.traces_for_layer(viewer, layer)
 
-    xaxis = cartesian_axis(viewer, 'x')
-    yaxis = cartesian_axis(viewer, 'y')
+    xaxis = rectilinear_axis(viewer, 'x')
+    yaxis = rectilinear_axis(viewer, 'y')
 
     return traces, xaxis, yaxis
 
@@ -128,8 +128,8 @@ def export_histogram(viewer):
         traces.append(trace)
         ymax = max(ymax, hist.max())
 
-    xaxis = cartesian_axis(viewer, 'x')
-    yaxis = cartesian_axis(viewer, 'y')
+    xaxis = rectilinear_axis(viewer, 'x')
+    yaxis = rectilinear_axis(viewer, 'y')
 
     return traces, xaxis, yaxis
 

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from glue.core.layout import Rectangle, snap_to_grid
 
-from glue_plotly.common import rectilinear_axis, sanitize, scatter2d
+from glue_plotly.common import data_count, layers_to_export, rectilinear_axis, sanitize, scatter2d
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -99,9 +99,10 @@ def export_scatter(viewer):
     plotly-formatted data dictionaries"""
     traces = []
 
-    for layer in viewer.layers:
-        if layer.enabled and layer.visible:
-            traces += scatter2d.traces_for_layer(viewer, layer)
+    layers = layers_to_export(viewer)
+    add_data_label = data_count(layers) > 1
+    for layer in layers:
+        traces += scatter2d.traces_for_layer(viewer, layer, add_data_label=add_data_label)
 
     xaxis = rectilinear_axis(viewer, 'x')
     yaxis = rectilinear_axis(viewer, 'y')

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
-
 try:
     from chart_studio import plotly
 except ImportError:
     plotly = None
 
 from glue.core.layout import Rectangle, snap_to_grid
-from glue.utils import categorical_ndarray
 
 from glue_plotly.common import cartesian_axis, sanitize, scatter2d
 
@@ -160,8 +157,7 @@ def build_plotly_call(app):
             if ct > 1:
                 yaxis['anchor'] = 'x' + suffix
                 for item in p:
-                    item['xaxis'] = 'x' + suffix
-                    item['yaxis'] = 'y' + suffix
+                    item.update(xaxis='x' + suffix, yaxis='y' + suffix)
             ct += 1
             args.extend(p)
 

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -79,7 +79,10 @@ def _fix_legend_duplicates(traces, layout):
     """Prevent repeat entries in the legend"""
     seen = set()
     for t in traces:
-        key = (t.name, t.marker.symbol, t.marker.color)
+        if isinstance(t, dict):
+            key = (t.get('name'), t.get('marker', {}).get('color'))
+        else:
+            key = (t.name, t.marker.symbol, t.marker.color)
         if key in seen:
             t['showlegend'] = False
         else:

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -10,7 +10,7 @@ except ImportError:
 from glue.core.layout import Rectangle, snap_to_grid
 from glue.utils import categorical_ndarray
 
-from glue_plotly.common import cartesian_axis, sanitize
+from glue_plotly.common import cartesian_axis, sanitize, scatter2d
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -101,35 +101,12 @@ def export_scatter(viewer):
     """Export a scatter viewer to a list of
     plotly-formatted data dictionaries"""
     traces = []
-    xatt, yatt = viewer.state.x_att, viewer.state.y_att
-    xcat = ycat = False
 
     for layer in viewer.layers:
         if not layer.visible:
             continue
-        data = layer.layer
-        xcat |= data.data.get_kind(xatt) == 'categorical'
-        ycat |= data.data.get_kind(yatt) == 'categorical'
 
-        marker = dict(symbol=SYM.get(data.style.marker, 'circle'),
-                      color=_color(data.style),
-                      size=data.style.markersize)
-
-        x, y = data[xatt], data[yatt]
-        if isinstance(x, categorical_ndarray):
-            x = x.codes
-        if isinstance(y, categorical_ndarray):
-            y = y.codes
-
-        x, y = sanitize(x, y)
-
-        trace = dict(x=x, y=y,
-                     type='scatter',
-                     mode='markers',
-                     marker=marker,
-                     name=data.label)
-
-        traces.append(trace)
+        traces += scatter2d.traces_for_layer(viewer, layer)
 
     xaxis = cartesian_axis(viewer, 'x')
     yaxis = cartesian_axis(viewer, 'y')

--- a/glue_plotly/web/qt/exporter.py
+++ b/glue_plotly/web/qt/exporter.py
@@ -7,6 +7,7 @@ import traceback
 import webbrowser
 
 from qtpy import QtWidgets
+from glue.config import settings
 from glue.utils import nonpartial
 from glue.utils.qt import load_ui, process_events
 from glue.utils.qt.widget_properties import TextProperty, ButtonProperty
@@ -135,6 +136,10 @@ class QtPlotlyExporter(QtWidgets.QDialog):
         # Get title and legend preferences from the window
         self.plotly_args[0]['layout']['showlegend'] = self.legend
         self.plotly_args[0]['layout']['title'] = self.title
+
+        # Get background color from settings
+        self.plotly_args[0]['layout']['paper_bgcolor'] = settings.BACKGROUND_COLOR
+        self.plotly_args[0]['layout']['plot_bgcolor'] = settings.BACKGROUND_COLOR
 
         try:
             plotly.sign_in(auth['username'], auth['api_key'])

--- a/glue_plotly/web/qt/tests/test_plotly.py
+++ b/glue_plotly/web/qt/tests/test_plotly.py
@@ -39,11 +39,12 @@ class TestPlotly(object):
         viewer.state.y_att = d.id['x']
 
         args, kwargs = build_plotly_call(self.app)
-        data = args[0]['data'][0]
+        data = args[0]['data'][0].to_plotly_json()
 
         expected = dict(type='scatter', mode='markers', name=d.label,
-                        marker=dict(size=6, color='rgba(255, 0, 0, 0.4)',
-                                    symbol='circle'))
+                        marker=dict(size=12, opacity=0.4,
+                                    color="#ff0000",
+                                    line=dict(width=0)))
         for k, v in expected.items():
             assert data[k] == v
 
@@ -161,9 +162,9 @@ class TestPlotly(object):
         args, kwargs = build_plotly_call(self.app)
 
         xaxis = dict(type='linear', rangemode='normal',
-                     range=[-0.5, 2.5], title='z', zeroline=False)
+                     range=[-0.5, 2.5], title=viewer.state.x_axislabel, zeroline=False)
         yaxis = dict(type='linear', rangemode='normal',
-                     range=[0, 1.05], title='', zeroline=False)
+                     range=[0, 1.2], title=viewer.state.y_axislabel, zeroline=False)
         layout = args[0]['layout']
         for k, v in layout['xaxis'].items():
             assert xaxis.get(k, v) == v

--- a/glue_plotly/web/qt/tests/test_plotly.py
+++ b/glue_plotly/web/qt/tests/test_plotly.py
@@ -94,9 +94,9 @@ class TestPlotly(object):
         args, kwargs = build_plotly_call(self.app)
 
         xaxis = dict(type='log', rangemode='normal',
-                     range=[1, 2], title='x', zeroline=False)
+                     range=[1, 2], title=viewer.state.x_axislabel, zeroline=False)
         yaxis = dict(type='linear', rangemode='normal',
-                     range=[2, 4], title='y', zeroline=False)
+                     range=[2, 4], title=viewer.state.y_axislabel, zeroline=False)
         layout = args[0]['layout']
         for k, v in layout['xaxis'].items():
             assert xaxis.get(k, v) == v


### PR DESCRIPTION
This PR refactors the code used in the HTML 2D scatter exporter so that it can be used by the corresponding web exporter as well. The goal is to have these common functions contain all of the real export logic, particularly for traces, so that the web exporter and HTML tool only need to handle context-specific stuff. A side effect of this is that the 2D scatter web exporter now has feature parity with the corresponding HTML exporter.

To achieve this, I've created a new `common` directory. This contains functionality specific to 2D scatter exports (`scatter2d.py`) as well as some routines that I think will be useful across multiple viewers (`common.py`). I also fixed a bug that I noticed along the way where points with zero opacity from a matplotlib colormap were not handled correctly.

Future PRs will do the same for the histogram viewer, as well as hopefully expand the web exporter to handle more viewer types.