### PR TITLE
Add profile viewer to web export

### DIFF
--- a/glue_plotly/common/profile.py
+++ b/glue_plotly/common/profile.py
@@ -1,0 +1,26 @@
+from glue.core import BaseData
+from plotly.graph_objs import Scatter
+
+from glue_plotly.common import fixed_color
+from glue_plotly.common.histogram import axis, layout_config  # noqa
+
+
+def traces_for_layer(viewer, layer, add_data_label=True):
+    layer_state = layer.state
+
+    x, y = layer_state.profile
+    if viewer.state.normalize:
+        y = layer_state.normalize_values(y)
+    line = dict(width=2*layer_state.linewidth,
+                shape='hvh' if layer_state.as_steps else 'linear',
+                color=fixed_color(layer))
+
+    name = layer.layer.label
+    if add_data_label and not isinstance(layer.layer, BaseData):
+        name += " ({0})".format(layer.layer.data.label)
+
+    profile_info = dict(hoverinfo='skip', line=line,
+                        opacity=layer_state.alpha, name=name,
+                        x=x, y=y)
+
+    return [Scatter(**profile_info)]

--- a/glue_plotly/html_exporters/histogram.py
+++ b/glue_plotly/html_exporters/histogram.py
@@ -37,7 +37,7 @@ class PlotlyHistogram1DExport(Tool):
         fig = go.Figure(layout=layout)
 
         layers = layers_to_export(self.viewer)
-        add_data_label = data_count(layers) > 0
+        add_data_label = data_count(layers) > 1
         for layer in layers:
             traces = traces_for_layer(self.viewer, layer, add_data_label=add_data_label)
             for trace in traces:

--- a/glue_plotly/html_exporters/profile.py
+++ b/glue_plotly/html_exporters/profile.py
@@ -1,12 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
-
 from qtpy import compat
-from glue.config import viewer_tool, settings
-from glue.core import Subset
-
-from ..utils import ticks_values
+from glue.config import viewer_tool
 
 try:
     from glue.viewers.common.qt.tool import Tool
@@ -14,6 +9,8 @@ except ImportError:
     from glue.viewers.common.tool import Tool
 
 from glue_plotly import PLOTLY_LOGO
+from glue_plotly.common import data_count, layers_to_export
+from glue_plotly.common.profile import layout_config, traces_for_layer
 
 from plotly.offline import plot
 import plotly.graph_objs as go
@@ -34,111 +31,15 @@ class PlotlyProfile1DExport(Tool):
         if not filename:
             return
 
-        width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
-
-        # set the aspect ratio of the axes, the tick label size, the axis label
-        # sizes, and the axes limits
-        layout_config = dict(
-            margin=dict(r=50, l=50, b=50, t=50),  # noqa
-            width=1200,
-            height=1200 * height / width,  # scale axis correctly
-            paper_bgcolor=settings.BACKGROUND_COLOR,
-            plot_bgcolor=settings.BACKGROUND_COLOR,
-            barmode="overlay",
-            bargap=0
-        )
-
-        x_axis = dict(
-            title=self.viewer.axes.get_xlabel(),
-            titlefont=dict(
-                family=DEFAULT_FONT,
-                size=2 * self.viewer.axes.xaxis.get_label().get_size(),
-                color=settings.FOREGROUND_COLOR
-            ),
-            showspikes=False,
-            linecolor=settings.FOREGROUND_COLOR,
-            tickcolor=settings.FOREGROUND_COLOR,
-            mirror=True,
-            ticks='outside',
-            showline=True,
-            showgrid=False,
-            showticklabels=True,
-            tickfont=dict(
-                family=DEFAULT_FONT,
-                size=1.5 * self.viewer.axes.xaxis.get_ticklabels()[
-                    0].get_fontsize(),
-                color=settings.FOREGROUND_COLOR),
-            range=[self.viewer.state.x_min, self.viewer.state.x_max]
-        )
-        y_axis = dict(
-            title=self.viewer.axes.get_ylabel(),
-            titlefont=dict(
-                family=DEFAULT_FONT,
-                size=2 * self.viewer.axes.yaxis.get_label().get_size(),
-                color=settings.FOREGROUND_COLOR),
-            showgrid=False,
-            showspikes=False,
-            linecolor=settings.FOREGROUND_COLOR,
-            tickcolor=settings.FOREGROUND_COLOR,
-            zeroline=False,
-            mirror=True,
-            ticks='outside',
-            showline=True,
-            range=[self.viewer.state.y_min, self.viewer.state.y_max],
-            showticklabels=True,
-            tickfont=dict(
-                family=DEFAULT_FONT,
-                size=1.5 * self.viewer.axes.yaxis.get_ticklabels()[
-                    0].get_fontsize(),
-                color=settings.FOREGROUND_COLOR),
-        )
-
-        axes = self.viewer.axes
-        xvals, xtext = ticks_values(axes, 'x')
-        if xvals and xtext:
-            x_axis.update(tickmode='array', tickvals=xvals, ticktext=xtext)
-        yvals, ytext = ticks_values(axes, 'y')
-        if yvals and ytext:
-            y_axis.update(tickmode='array', tickvals=yvals, ticktext=ytext)
-
-        layout_config.update(xaxis=x_axis, yaxis=y_axis)
-
-        layout = go.Layout(**layout_config)
-
+        config = layout_config(self.viewer)
+        layout = go.Layout(**config)
         fig = go.Figure(layout=layout)
 
-        for layer in self.viewer.layers:
-
-            layer_state = layer.state
-
-            if layer_state.visible and layer.enabled:
-
-                x, y = layer_state.profile
-                if self.viewer.state.normalize:
-                    y = layer_state.normalize_values(y)
-                line = dict(width=2*layer_state.linewidth)
-                line['shape'] = 'hvh' if layer_state.as_steps else 'linear'
-
-                if layer_state.color != '0.35':
-                    line['color'] = layer_state.color
-                else:
-                    line['color'] = 'gray'
-
-                # set log
-                if self.viewer.state.x_log:
-                    fig.update_xaxes(type='log', dtick=1, minor_ticks='outside',
-                                     range=[np.log10(self.viewer.state.x_min), np.log10(self.viewer.state.x_max)]
-                                     )
-                if self.viewer.state.y_log:
-                    fig.update_yaxes(type='log', dtick=1, minor_ticks='outside',
-                                     range=[np.log10(self.viewer.state.y_min), np.log10(self.viewer.state.y_max)]
-                                     )
-
-                label = layer.layer.label
-                if isinstance(layer.layer, Subset):
-                    label += " ({0})".format(layer.layer.data.label)
-
-                profile_info = dict(hoverinfo='skip', line=line, opacity=layer_state.alpha, name=label, x=x, y=y)
-                fig.add_scatter(**profile_info)
+        layers = layers_to_export(self.viewer)
+        add_data_label = data_count(layers) > 1
+        for layer in layers:
+            traces = traces_for_layer(self.viewer, layer, add_data_label=add_data_label)
+            for trace in traces:
+                fig.add_trace(trace)
 
         plot(fig, include_mathjax='cdn', filename=filename, auto_open=False)

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -7,7 +7,8 @@ except ImportError:
 
 from glue.core.layout import Rectangle, snap_to_grid
 
-from glue_plotly.common import data_count, histogram, layers_to_export, rectilinear_axis, scatter2d
+from glue_plotly.common import histogram, profile, scatter2d, \
+    data_count, layers_to_export, rectilinear_axis
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -121,6 +122,21 @@ def export_histogram(viewer):
     # TODO: Can we use MathJax (or some other LaTeX formatting) inside Chart Studio?
     xaxis = histogram.axis(viewer, 'x', glue_ticks=False)
     yaxis = histogram.axis(viewer, 'y', glue_ticks=False)
+
+    return traces, xaxis, yaxis
+
+
+def export_profile(viewer):
+    traces = []
+    layers = layers_to_export(viewer)
+    add_data_label = data_count(layers) > 1
+    for layer in layers:
+        traces += profile.traces_for_layer(viewer, layer, add_data_label=add_data_label)
+
+    # For now, set glue_ticks to False
+    # TODO: Can we use MathJax (or some other LaTeX formatting) inside Chart Studio?
+    xaxis = profile.axis(viewer, 'x', glue_ticks=False)
+    yaxis = profile.axis(viewer, 'y', glue_ticks=False)
 
     return traces, xaxis, yaxis
 

--- a/glue_plotly/web/qt/__init__.py
+++ b/glue_plotly/web/qt/__init__.py
@@ -2,13 +2,16 @@ def setup():
 
     from glue.config import exporters
     from glue_plotly.web.export_plotly import (can_save_plotly, DISPATCH,
-                                               export_scatter, export_histogram)
+                                               export_scatter, export_histogram,
+                                               export_profile)
     from glue_plotly.web.qt.exporter import save_plotly
 
     from glue.viewers.scatter.qt import ScatterViewer
     from glue.viewers.histogram.qt import HistogramViewer
+    from glue.viewers.profile.qt import ProfileViewer
 
     DISPATCH[ScatterViewer] = export_scatter
     DISPATCH[HistogramViewer] = export_histogram
+    DISPATCH[ProfileViewer] = export_profile
 
     exporters.add('Plotly', save_plotly, can_save_plotly)


### PR DESCRIPTION
This PR allows web export of the profile viewer. To do this, the profile export code was refactored to allow reuse between the HTML and web exporters.