### PR TITLE
Refactor image viewer export functionality

### DIFF
--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -1,13 +1,22 @@
+from inspect import cleandoc
 from uuid import uuid4
+
+from astropy.visualization import ManualInterval, ContrastBiasStretch
+from glue.viewers.image.layer_artist import PixelSubsetState
 from matplotlib.colors import to_rgb
 import numpy as np
 
-from glue.viewers.image.state import ImageLayerState, ImageSubsetLayerState
+from glue.config import settings
+from glue.utils import ensure_numerical
+from glue.viewers.image.composite_array import STRETCHES
+from glue.viewers.image.state import BaseData, ImageLayerState, ImageSubsetLayerState
 from glue.viewers.scatter.state import IncompatibleAttribute, ScatterLayerState
 
-from plotly.graph_objects import Heatmap, Scatter
+from plotly.graph_objects import Heatmap, Image, Scatter
 
-from glue_plotly.common import base_layout_config, fixed_color, layers_to_export
+from glue_plotly.common import base_layout_config, color_info, fixed_color, layers_to_export
+from glue_plotly.common.common import DEFAULT_FONT
+from glue_plotly.utils import cleaned_labels
 
 
 def slice_to_bound(slc, size):
@@ -19,15 +28,130 @@ def slice_to_bound(slc, size):
 
 def background_color(viewer):
     using_colormaps = viewer.state.color_mode == 'Colormaps'
-    bg_color = [256, 256, 256, 1] if using_colormaps else [0, 0, 0, 1]
-    return bg_color
-
+    if using_colormaps:
+        return [256, 256, 256, 1]
+    else:
+        img = viewer.axes._composite()
+        bg_color = [_ for _ in img[0][0]]
+        for i in range(3):
+            bg_color[i] *= 256
+        return bg_color
 
 def layout_config(viewer):
     bg_color = background_color(viewer)
     return base_layout_config(viewer,
                               plot_bgcolor='rgba{0}'.format(tuple(bg_color)),
                               showlegend=True)
+
+
+def axes_data(viewer):
+    axes_data = {}
+
+    axes = viewer.axes
+    xmin, xmax = axes.get_xlim()
+    ymin, ymax = axes.get_ylim()
+
+    for helper in axes.coords:
+        ticks = helper.ticks
+        ticklabels = helper.ticklabels
+        for axis in ticklabels.get_visible_axes():
+            ax = 'x' if axis in ['t', 'b'] else 'y'
+            ax_idx = 0 if ax == 'x' else 1
+            locations = sorted([loc[0][ax_idx] for loc in ticks.ticks_locs[axis]])
+            labels = ticklabels.text[axis]
+            if ax == 'y':
+                labels = list(reversed(labels))
+            labels = cleaned_labels(labels)
+            if ax == 'x':
+                axis_range = [xmin, xmax]
+            else:
+                axis_range = [ymin, ymax]
+            axis_info = dict(
+                showspikes=False,
+                linecolor=settings.FOREGROUND_COLOR,
+                tickcolor=settings.FOREGROUND_COLOR,
+                ticks='outside',
+                zeroline=False,
+                showline=False,
+                showgrid=False,
+                range=axis_range,
+                showticklabels=True,
+                tickmode='array',
+                tickvals=locations,
+                ticktext=labels,
+                tickfont=dict(
+                    family=DEFAULT_FONT,
+                    size=1.5 * axes.xaxis.get_ticklabels()[0].get_fontsize(),
+                    color=settings.FOREGROUND_COLOR)
+            )
+
+            if axis == 'b':
+                axis_info.update(
+                    title=viewer.axes.get_xlabel(),
+                    titlefont=dict(
+                        family=DEFAULT_FONT,
+                        size=2 * axes.xaxis.get_label().get_size(),
+                        color=settings.FOREGROUND_COLOR
+                    )
+                )
+                axes_data['xaxis'] = axis_info
+            elif axis == 'l':
+                axis_info.update(
+                    title=viewer.axes.get_ylabel(),
+                    titlefont=dict(
+                        family=DEFAULT_FONT,
+                        size=2 * axes.yaxis.get_label().get_size(),
+                        color=settings.FOREGROUND_COLOR
+                    )
+                )
+                axes_data['yaxis'] = axis_info
+            elif axis == 't':
+                axis_info.update(overlaying='x', side='top')
+                axes_data['xaxis2'] = axis_info
+            elif axis == 'r':
+                axis_info.update(overlaying='y', side='right')
+                axes_data['yaxis2'] = axis_info
+            else:
+                continue
+
+    return axes_data
+
+
+def shape(viewer):
+    xy_axes = sorted([viewer.state.x_att.axis, viewer.state.y_att.axis])
+    return [viewer.state.reference_data.shape[i] for i in xy_axes]
+
+
+def size_info(layer):
+    state = layer.state
+    if state.size_mode == 'Fixed':
+       return state.size 
+    else:
+        s = ensure_numerical(state.layer[state.size_att].ravel())
+        size = 25 * (s - state.size_vmin) / (
+                        state.size_vmax - state.size_vmin)
+        size[np.isnan(size)] = 0
+        size[size< 0] = 0
+        return size
+
+
+def colorscale_info(layer, interval, contrast_bias):
+    if layer.state.v_min > layer.state.v_max:
+        cmap = layer.state.cmap.reversed()
+        bounds = [layer.state.v_max, layer.state.v_min]
+    else:
+        cmap = layer.state.cmap
+        bounds = [layer.state.v_min, layer.state.v_max]
+    mapped_bounds = STRETCHES[layer.state.stretch]()(contrast_bias(interval(bounds)))
+    unmapped_space = np.linspace(0, 1, 60)
+    mapped_space = np.linspace(mapped_bounds[0], mapped_bounds[1], 60)
+    color_space = [cmap(b)[:3] for b in mapped_space]
+    color_values = [tuple(256 * v for v in p) for p in color_space]
+    colorscale = [[0, 'rgb{0}'.format(color_values[0])]] + \
+                 [[u, 'rgb{0}'.format(c)] for u, c in zip(unmapped_space, color_values)] + \
+                 [[1, 'rgb{0}'.format(color_values[-1])]]
+    return mapped_bounds, colorscale
+
 
 
 def layers_by_type(viewer):
@@ -53,6 +177,32 @@ def full_view_transpose(viewer):
             full_view[i] = slice_to_bound(full_view[i], state.reference_data.shape[i])
     
     return full_view, transpose
+
+
+def empty_secondary_layer(shape, secondary_x, secondary_y):
+    bg = np.ones(shape)
+    secondary_info = dict(z=bg,
+                          colorscale=[[0, 'rgb(0,0,0)'], [1, 'rgb(0,0,0)']],
+                          hoverinfo='skip',
+                          opacity=0,
+                          showscale=False,
+                          xaxis='x2' if secondary_x else 'x',
+                          yaxis='y2' if secondary_y else 'y'
+                    )
+    return Heatmap(**secondary_info)
+
+
+def background_heatmap_layer(viewer):
+    """
+    This function creates an all-white heatmap which we can use as the bottom layer
+    when the viewer is using colormap, to match what we see in glue
+    """
+    bg = np.ones(shape(viewer))
+    bottom_color = (256, 256, 256)
+    bottom_colorstring = 'rgb{0}'.format(bottom_color)
+    bottom_info = dict(z=bg, hoverinfo='skip', opacity=1, showscale=False,
+                       colorscale=[[0, bottom_colorstring], [1, bottom_colorstring]])
+    return Heatmap(**bottom_info)
 
 
 def traces_for_pixel_subset_layer(viewer, layer):
@@ -113,3 +263,127 @@ def traces_for_nonpixel_subset_layer(viewer, layer, full_view, transpose):
     )
 
     return [Heatmap(**image_info)]
+
+
+def traces_for_scatter_layer(viewer, layer, hover_data=None, add_data_label=True):
+    viewer_state = viewer.state
+    layer_state = layer.state
+
+    x = layer_state.layer[viewer_state.x_att]
+    y = layer_state.layer[viewer_state.y_att]
+
+    marker = dict(color=color_info(layer),
+                  opacity = layer_state.alpha,
+                  line=dict(width=0),
+                  size=size_info(layer),
+                  sizemin=1
+            )
+    
+    if np.sum(hover_data) == 0:
+        hoverinfo = 'skip'
+        hovertext = None
+    else:
+        hoverinfo = 'text'
+        hovertext = ['' for _ in range(layer_state.layer.shape[0])]
+        for i in range(len(layer_state.layer.components)):
+            if hover_data[i]:
+                hover_values = layer_state.layer.components[i].label
+                for k in range(len(hover_values)):
+                    hovertext[k] = (hovertext[k] + '{}: {} <br>'
+                                    .format(layer_state.layer.components[i].label,
+                                            hover_values[k]))
+
+    name = layer_state.layer.label
+    if add_data_label and not isinstance(layer.layer, BaseData):
+        name += " ({0})".format(layer.layer.data.label)
+    scatter_info = dict(mode='markers',
+                        marker=marker,
+                        x=x,
+                        y=y,
+                        xaxis='x',
+                        yaxis='y',
+                        hoverinfo=hoverinfo,
+                        hovertext=hovertext
+                        name=name
+                    )
+
+    return [Scatter(**scatter_info)]
+
+
+def traces_for_image_layer(layer):
+    layer_state = layer.state
+
+    interval = ManualInterval(layer_state.v_min, layer_state.v_max)
+    constrast_bias = ContrastBiasStretch(layer_state.contrast, layer_state.bias)
+    array = layer.get_image_data
+    if callable(array):
+        array = array(bounds=None)
+    if array is None:
+        return []
+
+    if np.isscalar(array):
+        array = np.atleast_2d(array)
+
+    img = STRETCHES[layer_state.stretch]()(constrast_bias(interval(array)))
+    img[np.isnan(img)] = 0
+
+    z_bounds, colorscale = colorscale_info(layer, interval, constrast_bias)
+    image_info = dict(z=img,
+                      colorscale=colorscale,
+                      hoverinfo='skip',
+                      xaxis='x',
+                      yaxis='y',
+                      zmin=z_bounds[0],
+                      zmax=z_bounds[1],
+                      name=layer_state.layer.label,
+                      showscale=False,
+                      showlegend=True,
+                      opacity=layer_state.alpha
+                )
+    return [Heatmap(**image_info)]
+
+
+def single_color_trace(viewer):
+    img = viewer.axes._composite()
+    img[:, :, :3] *= 256
+    image_info = dict(z=img,
+                      opacity=1,
+                      hoverinfo='skip'
+                )
+
+    return Image(**image_info)
+
+
+def traces(viewer, secondary_x=False, secondary_y=False, hover_selections=None, add_data_label=True):
+    traces = []
+    layers = layers_by_type(viewer)
+    using_colormaps = viewer.state.color_mode == 'Colormaps'
+
+    has_nonpixel_subset = any(not isinstance(layer.layer.subset_state, PixelSubsetState)
+                              for layer in layers['image_subset'])
+    if has_nonpixel_subset:
+        full_view, transpose = full_view_transpose(viewer)
+
+    if using_colormaps:
+        for layer in layers['image']:
+            traces += traces_for_image_layer(layer)
+    else:
+        traces.append(single_color_trace(viewer))
+
+    for layer in layers['image_subset']:
+        subset_state = layer.layer.subset_state
+        if isinstance(subset_state, PixelSubsetState):
+            traces += traces_for_pixel_subset_layer(viewer, layer)
+        else:
+            traces += traces_for_nonpixel_subset_layer(viewer, layer, full_view, transpose)
+
+    for layer in layers['scatter']:
+        traces += traces_for_scatter_layer(viewer, layer,
+                                           hover_data=hover_selections[layer.state.layer.label],
+                                           add_data_label=add_data_label)
+
+
+    if secondary_x or secondary_y:
+        traces.append(empty_secondary_layer(viewer, secondary_x, secondary_y))
+
+    return traces

--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -1,4 +1,3 @@
-from inspect import cleandoc
 from uuid import uuid4
 
 from astropy.visualization import ManualInterval, ContrastBiasStretch
@@ -125,7 +124,7 @@ def shape(viewer):
 def size_info(layer):
     state = layer.state
     if state.size_mode == 'Fixed':
-       return state.size 
+       return state.size
     else:
         s = ensure_numerical(state.layer[state.size_att].ravel())
         size = 25 * (s - state.size_vmin) / (
@@ -153,7 +152,6 @@ def colorscale_info(layer, interval, contrast_bias):
     return mapped_bounds, colorscale
 
 
-
 def layers_by_type(viewer):
     layers = sorted(layers_to_export(viewer), key=lambda lyr: lyr.zorder)
     scatter_layers, image_layers, image_subset_layers = [], [], []
@@ -167,6 +165,7 @@ def layers_by_type(viewer):
 
     return dict(scatter=scatter_layers, image=image_layers, image_subset=image_subset_layers)
 
+
 def full_view_transpose(viewer):
     state = viewer.state
     full_view, _agg_func, transpose = state.numpy_slice_aggregation_transpose
@@ -175,12 +174,12 @@ def full_view_transpose(viewer):
     for i in range(state.reference_data.ndim):
         if isinstance(full_view[i], slice):
             full_view[i] = slice_to_bound(full_view[i], state.reference_data.shape[i])
-    
+
     return full_view, transpose
 
 
-def empty_secondary_layer(shape, secondary_x, secondary_y):
-    bg = np.ones(shape)
+def empty_secondary_layer(viewer, secondary_x, secondary_y):
+    bg = np.ones(shape(viewer))
     secondary_info = dict(z=bg,
                           colorscale=[[0, 'rgb(0,0,0)'], [1, 'rgb(0,0,0)']],
                           hoverinfo='skip',
@@ -220,7 +219,7 @@ def traces_for_pixel_subset_layer(viewer, layer):
             ),
             opacity = state.alpha * 0.5,
             name = state.layer.label,
-            legendgroup=uuid4()
+            legendgroup=uuid4().hex
         )
 
         x_line_data = {**line_data, 'x': [x, x], 'y': [ymin, ymax], 'showlegend': True}
@@ -278,7 +277,7 @@ def traces_for_scatter_layer(viewer, layer, hover_data=None, add_data_label=True
                   size=size_info(layer),
                   sizemin=1
             )
-    
+
     if np.sum(hover_data) == 0:
         hoverinfo = 'skip'
         hovertext = None
@@ -303,7 +302,7 @@ def traces_for_scatter_layer(viewer, layer, hover_data=None, add_data_label=True
                         xaxis='x',
                         yaxis='y',
                         hoverinfo=hoverinfo,
-                        hovertext=hovertext
+                        hovertext=hovertext,
                         name=name
                     )
 
@@ -365,6 +364,7 @@ def traces(viewer, secondary_x=False, secondary_y=False, hover_selections=None, 
         full_view, transpose = full_view_transpose(viewer)
 
     if using_colormaps:
+        traces.append(background_heatmap_layer(viewer))
         for layer in layers['image']:
             traces += traces_for_image_layer(layer)
     else:
@@ -381,7 +381,6 @@ def traces(viewer, secondary_x=False, secondary_y=False, hover_selections=None, 
         traces += traces_for_scatter_layer(viewer, layer,
                                            hover_data=hover_selections[layer.state.layer.label],
                                            add_data_label=add_data_label)
-
 
     if secondary_x or secondary_y:
         traces.append(empty_secondary_layer(viewer, secondary_x, secondary_y))

--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -36,6 +36,7 @@ def background_color(viewer):
             bg_color[i] *= 256
         return bg_color
 
+
 def layout_config(viewer):
     bg_color = background_color(viewer)
     return base_layout_config(viewer,
@@ -124,21 +125,15 @@ def shape(viewer):
 def image_size_info(layer):
     state = layer.state
     if state.size_mode == 'Fixed':
-       return state.size
+        return state.size
     else:
         s = ensure_numerical(state.layer[state.size_att].ravel())
         size = 25 * (s - state.size_vmin) / (
                         state.size_vmax - state.size_vmin)
         size[np.isnan(size)] = 0
-        size[size< 0] = 0
+        size[size < 0] = 0
         return size
 
-
-def size_info(layer):
-    if isinstance(layer, ScatterLayerState):
-        return scatter_size_info(layer)
-    else:
-        return image_size_info(layer)
 
 def colorscale_info(layer, interval, contrast_bias):
     if layer.state.v_min > layer.state.v_max:
@@ -192,8 +187,7 @@ def empty_secondary_layer(viewer, secondary_x, secondary_y):
                           opacity=0,
                           showscale=False,
                           xaxis='x2' if secondary_x else 'x',
-                          yaxis='y2' if secondary_y else 'y'
-                    )
+                          yaxis='y2' if secondary_y else 'y')
     return Heatmap(**secondary_info)
 
 
@@ -223,8 +217,8 @@ def traces_for_pixel_subset_layer(viewer, layer):
             marker=dict(
                 color=state.color
             ),
-            opacity = state.alpha * 0.5,
-            name = state.layer.label,
+            opacity=state.alpha * 0.5,
+            name=state.layer.label,
             legendgroup=uuid4().hex
         )
 
@@ -240,11 +234,8 @@ def traces_for_nonpixel_subset_layer(viewer, layer, full_view, transpose):
     subset_state = layer.layer.subset_state
     ref_data = viewer.state.reference_data
     color = fixed_color(layer)
-    buffer = ref_data \
-            .compute_fixed_resolution_buffer(full_view,
-                                             target_data=ref_data,
-                                             broadcast=False,
-                                             subset_state=subset_state)
+    buffer = ref_data.compute_fixed_resolution_buffer(full_view, target_data=ref_data,
+                                                      broadcast=False, subset_state=subset_state)
     if transpose:
         buffer = buffer.transpose()
 
@@ -277,13 +268,12 @@ def traces_for_scatter_layer(viewer, layer, hover_data=None, add_data_label=True
     x = layer_state.layer[viewer_state.x_att].copy()
     y = layer_state.layer[viewer_state.y_att].copy()
     mask, (x, y) = sanitize(x, y)
-    
+
     marker = dict(color=color_info(layer),
-                  opacity = layer_state.alpha,
+                  opacity=layer_state.alpha,
                   line=dict(width=0),
                   size=scatter_size_info(layer, mask),
-                  sizemin=1
-            )
+                  sizemin=1)
 
     if np.sum(hover_data) == 0:
         hoverinfo = 'skip'
@@ -293,7 +283,8 @@ def traces_for_scatter_layer(viewer, layer, hover_data=None, add_data_label=True
         hovertext = ['' for _ in range(layer_state.layer.shape[0])]
         for i in range(len(layer_state.layer.components)):
             if hover_data[i]:
-                hover_values = layer_state.layer.components[i].label
+                label = layer_state.layer.components[i].label
+                hover_values = layer_state.layer[label][mask]
                 for k in range(len(hover_values)):
                     hovertext[k] = (hovertext[k] + '{}: {} <br>'
                                     .format(layer_state.layer.components[i].label,
@@ -310,8 +301,7 @@ def traces_for_scatter_layer(viewer, layer, hover_data=None, add_data_label=True
                         yaxis='y',
                         hoverinfo=hoverinfo,
                         hovertext=hovertext,
-                        name=name
-                    )
+                        name=name)
 
     return [Scatter(**scatter_info)]
 
@@ -344,8 +334,7 @@ def traces_for_image_layer(layer):
                       name=layer_state.layer.label,
                       showscale=False,
                       showlegend=True,
-                      opacity=layer_state.alpha
-                )
+                      opacity=layer_state.alpha)
     return [Heatmap(**image_info)]
 
 
@@ -354,8 +343,7 @@ def single_color_trace(viewer):
     img[:, :, :3] *= 256
     image_info = dict(z=img,
                       opacity=1,
-                      hoverinfo='skip'
-                )
+                      hoverinfo='skip')
 
     return Image(**image_info)
 

--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -1,0 +1,115 @@
+from uuid import uuid4
+from matplotlib.colors import to_rgb
+import numpy as np
+
+from glue.viewers.image.state import ImageLayerState, ImageSubsetLayerState
+from glue.viewers.scatter.state import IncompatibleAttribute, ScatterLayerState
+
+from plotly.graph_objects import Heatmap, Scatter
+
+from glue_plotly.common import base_layout_config, fixed_color, layers_to_export
+
+
+def slice_to_bound(slc, size):
+    min, max, step = slc.indices(size)
+    n = (max - min - 1) // step
+    max = min + step * n
+    return min, max, n + 1
+
+
+def background_color(viewer):
+    using_colormaps = viewer.state.color_mode == 'Colormaps'
+    bg_color = [256, 256, 256, 1] if using_colormaps else [0, 0, 0, 1]
+    return bg_color
+
+
+def layout_config(viewer):
+    bg_color = background_color(viewer)
+    return base_layout_config(viewer,
+                              plot_bgcolor='rgba{0}'.format(tuple(bg_color)),
+                              showlegend=True)
+
+
+def layers_by_type(viewer):
+    layers = sorted(layers_to_export(viewer), key=lambda lyr: lyr.zorder)
+    scatter_layers, image_layers, image_subset_layers = [], [], []
+    for layer in layers:
+        if isinstance(layer.state, ImageLayerState):
+            image_layers.append(layer)
+        elif isinstance(layer.state, ImageSubsetLayerState):
+            image_subset_layers.append(layer)
+        elif isinstance(layer.state, ScatterLayerState):
+            scatter_layers.append(layer)
+
+    return dict(scatter=scatter_layers, image=image_layers, image_subset=image_subset_layers)
+
+def full_view_transpose(viewer):
+    state = viewer.state
+    full_view, _agg_func, transpose = state.numpy_slice_aggregation_transpose
+    full_view[state.x_att.axis] = slice(None)
+    full_view[state.y_att.axis] = slice(None)
+    for i in range(state.reference_data.ndim):
+        if isinstance(full_view[i], slice):
+            full_view[i] = slice_to_bound(full_view[i], state.reference_data.shape[i])
+    
+    return full_view, transpose
+
+
+def traces_for_pixel_subset_layer(viewer, layer):
+    state = layer.state
+    subset_state = layer.layer.subset_state
+    xmin, xmax = viewer.axes.get_xlim()
+    ymin, ymax = viewer.axes.get_ylim()
+
+    try:
+        x, y = subset_state.get_xy(layer.layer.data, viewer.state.x_att.axis, viewer.state.y_att.axis)
+        line_data = dict(
+            mode="lines",
+            marker=dict(
+                color=state.color
+            ),
+            opacity = state.alpha * 0.5,
+            name = state.layer.label,
+            legendgroup=uuid4()
+        )
+
+        x_line_data = {**line_data, 'x': [x, x], 'y': [ymin, ymax], 'showlegend': True}
+        y_line_data = {**line_data, 'x': [xmin, xmax], 'y': [y, y], 'showlegend': False}
+        return [Scatter(**x_line_data), Scatter(**y_line_data)]
+    except IncompatibleAttribute:
+        return []
+
+
+def traces_for_nonpixel_subset_layer(viewer, layer, full_view, transpose):
+    layer_state = layer.state
+    subset_state = layer.layer.subset_state
+    ref_data = viewer.state.reference_data
+    color = fixed_color(layer)
+    buffer = ref_data \
+            .compute_fixed_resolution_buffer(full_view,
+                                             target_data=ref_data,
+                                             broadcast=False,
+                                             subset_state=subset_state)
+    if transpose:
+        buffer = buffer.transpose()
+
+    vf = np.vectorize(int)
+    img = vf(buffer)
+    rgb_color = to_rgb(color)
+
+    # We use alpha = 0 for the bottom of the colorscale since we don't want
+    # anything outside the subset to contribute
+    colorscale = [[0, 'rgba(0,0,0,0)'], [1, 'rgb{0}'.format(tuple(256 * v for v in rgb_color))]]
+    image_info = dict(
+        z=img,
+        colorscale=colorscale,
+        hoverinfo='skip',
+        xaxis='x',
+        yaxis='y',
+        name=layer_state.layer.label,
+        opacity=layer_state.alpha * 0.5,
+        showscale=False,
+        showlegend=True
+    )
+
+    return [Heatmap(**image_info)]

--- a/glue_plotly/html_exporters/image.py
+++ b/glue_plotly/html_exporters/image.py
@@ -37,7 +37,7 @@ class PlotlyImage2DExport(Tool):
 
     @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
     def _export_to_plotly(self, filename, checked_dictionary):
-        
+
         layers = layers_to_export(self.viewer)
         add_data_label = data_count(layers) > 1
 

--- a/glue_plotly/html_exporters/image.py
+++ b/glue_plotly/html_exporters/image.py
@@ -1,24 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict
-
-from astropy.visualization import (ManualInterval, ContrastBiasStretch)
 import numpy as np
-from matplotlib.colors import rgb2hex, to_rgb, Normalize
 
 from qtpy import compat
 from qtpy.QtWidgets import QDialog
 
-from glue.config import viewer_tool, settings
+from glue.config import viewer_tool
 from glue.core import DataCollection, Data
-from glue.core.exceptions import IncompatibleAttribute
-from glue.utils import ensure_numerical
 from glue.utils.qt import messagebox_on_error
 from glue.utils.qt.threading import Worker
-from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
-from glue.viewers.image.composite_array import STRETCHES
 
-from ..utils import cleaned_labels
 from .. import save_hover, export_dialog
 
 try:
@@ -27,7 +18,8 @@ except ImportError:
     from glue.viewers.common.tool import Tool
 
 from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
-from glue_plotly.common.image import layers_by_type, slice_to_bound
+from glue_plotly.common import data_count, layers_to_export
+from glue_plotly.common.image import axes_data, layers_by_type, layout_config, traces
 
 import plotly.graph_objects as go
 from plotly.offline import plot
@@ -44,346 +36,29 @@ class PlotlyImage2DExport(Tool):
     tool_tip = 'Save Plotly HTML page'
 
     @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
-    def _export_to_plotly(self, filename, layers, checked_dictionary):
-        width, height = self.viewer.figure.get_size_inches() * self.viewer.figure.dpi
+    def _export_to_plotly(self, filename, checked_dictionary):
+        
+        layers = layers_to_export(self.viewer)
+        add_data_label = data_count(layers) > 1
 
-        xmin, xmax = self.viewer.axes.get_xlim()
-        ymin, ymax = self.viewer.axes.get_ylim()
+        config = layout_config(self.viewer)
 
-        viewer_state = self.viewer.state
-        axes = self.viewer.axes
-
-        # set the aspect ratio of the axes, the tick label size, the axis label
-        # sizes, and the axes limits
-        using_colormaps = viewer_state.color_mode == 'Colormaps'
-        bg_color = [256, 256, 256, 1] if using_colormaps else [0, 0, 0, 1]
-        layout_config = dict(
-            margin=dict(r=50, l=50, b=50, t=50),  # noqa
-            width=1200,
-            height=1200 * height / width,  # scale axis correctly
-            paper_bgcolor=settings.BACKGROUND_COLOR,
-            plot_bgcolor='rgba{0}'.format(tuple(bg_color)),
-            showlegend=True
-        )
-
-        axis_data = {}
-        secondary_x = False
-        secondary_y = False
-        for helper in axes.coords:
-            ticks = helper.ticks
-            ticklabels = helper.ticklabels
-            for axis in ticklabels.get_visible_axes():
-                xy = 'x' if axis in ['t', 'b'] else 'y'
-                xy_idx = 0 if xy == 'x' else 1
-                locations = sorted([loc[0][xy_idx] for loc in ticks.ticks_locs[axis]])
-                labels = ticklabels.text[axis]
-                if xy == 'y':
-                    labels = list(reversed(labels))
-                labels = cleaned_labels(labels)
-                if xy == 'x':
-                    axis_range = [xmin, xmax]
-                else:
-                    axis_range = [ymin, ymax]
-                axis_info = dict(
-                    showspikes=False,
-                    linecolor=settings.FOREGROUND_COLOR,
-                    tickcolor=settings.FOREGROUND_COLOR,
-                    ticks='outside',
-                    zeroline=False,
-                    showline=False,
-                    showgrid=False,
-                    range=axis_range,
-                    showticklabels=True,
-                    tickmode='array',
-                    tickvals=locations,
-                    ticktext=labels,
-                    tickfont=dict(
-                        family=DEFAULT_FONT,
-                        size=1.5 * self.viewer.axes.xaxis.get_ticklabels()[
-                            0].get_fontsize(),
-                        color=settings.FOREGROUND_COLOR)
-                )
-
-                if axis == 'b':
-                    axis_info.update(
-                        title=self.viewer.axes.get_xlabel(),
-                        titlefont=dict(
-                            family=DEFAULT_FONT,
-                            size=2 * self.viewer.axes.xaxis.get_label().get_size(),
-                            color=settings.FOREGROUND_COLOR
-                        ),
-                    )
-                    axis_data["xaxis"] = axis_info
-                elif axis == 'l':
-                    axis_info.update(
-                        title=self.viewer.axes.get_ylabel(),
-                        titlefont=dict(
-                            family=DEFAULT_FONT,
-                            size=2 * self.viewer.axes.yaxis.get_label().get_size(),
-                            color=settings.FOREGROUND_COLOR
-                        ),
-                    )
-                    axis_data["yaxis"] = axis_info
-                elif axis == 't':
-                    axis_info.update(overlaying='x', side='top')
-                    axis_data["xaxis2"] = axis_info
-                    secondary_x = True
-                elif axis == 'r':
-                    axis_info.update(overlaying='y', side='right')
-                    axis_data["yaxis2"] = axis_info
-                    secondary_y = True
-                else:
-                    continue
-
-        layout_config.update(**axis_data)
+        ax = axes_data(self.viewer)
+        config.update(**ax)
+        secondary_x = 'xaxis2' in ax
+        secondary_y = 'yaxis2' in ax
 
         if secondary_x or secondary_y:
             fig = make_subplots(specs=[[{"secondary_y": True}]], horizontal_spacing=0, vertical_spacing=0)
-            fig.update_layout(**layout_config)
+            fig.update_layout(**config)
         else:
-            layout = go.Layout(**layout_config)
+            layout = go.Layout(**config)
             fig = go.Figure(layout=layout)
 
-        image_layers = layers["image"]
-        image_subset_layers = layers["image_subset"]
-        scatter_layers = layers["scatter"]
-
-        has_nonpixel_subset = any(not isinstance(layer.layer.subset_state, PixelSubsetState)
-                                  for layer in image_subset_layers)
-        if has_nonpixel_subset:
-            full_view, agg_func, transpose = viewer_state.numpy_slice_aggregation_transpose
-            full_view[viewer_state.x_att.axis] = slice(None)
-            full_view[viewer_state.y_att.axis] = slice(None)
-            for i in range(viewer_state.reference_data.ndim):
-                if isinstance(full_view[i], slice):
-                    full_view[i] = slice_to_bound(full_view[i], viewer_state.reference_data.shape[i])
-
-        # This block of code adds an all-white heatmap as the bottom layer when using colormaps
-        # to match what we see in glue
-        if using_colormaps:
-            xy_axes = sorted([viewer_state.x_att.axis, viewer_state.y_att.axis])
-            shape = [viewer_state.reference_data.shape[i] for i in xy_axes]
-            bg = np.ones(shape)
-            legend_groups = defaultdict(int)
-            bottom_color = (256, 256, 256)
-            bottom_colorstring = 'rgb{0}'.format(bottom_color)
-            bottom_info = dict(z=bg,
-                               colorscale=[[0, bottom_colorstring], [1, bottom_colorstring]],
-                               hoverinfo='skip',
-                               opacity=1,
-                               showscale=False)
-
-            layers_to_add = [[fig.add_heatmap, bottom_info]]
-
-            for i, layer in enumerate(image_layers):
-
-                layer_state = layer.state
-
-                interval = ManualInterval(layer_state.v_min, layer_state.v_max)
-                contrast_bias = ContrastBiasStretch(layer_state.contrast, layer_state.bias)
-                array = layer.get_image_data
-                if callable(array):
-                    array = array(bounds=None)
-                if array is None:
-                    continue
-
-                if np.isscalar(array):
-                    array = np.atleast_2d(array)
-
-                img = STRETCHES[layer_state.stretch]()(contrast_bias(interval(array)))
-                img[np.isnan(img)] = 0
-
-                if layer_state.v_min > layer_state.v_max:
-                    cmap = layer_state.cmap.reversed()
-                    bounds = [layer_state.v_max, layer_state.v_min]
-                else:
-                    cmap = layer_state.cmap
-                    bounds = [layer_state.v_min, layer_state.v_max]
-                mapped_bounds = STRETCHES[layer_state.stretch]()(contrast_bias(interval(bounds)))
-                unmapped_space = np.linspace(0, 1, 60)
-                mapped_space = np.linspace(mapped_bounds[0], mapped_bounds[1], 60)
-                color_space = [cmap(b)[:3] for b in mapped_space]
-                color_values = [tuple(256 * v for v in p) for p in color_space]
-                colorscale = [[0, 'rgb{0}'.format(color_values[0])]] + \
-                             [[u, 'rgb{0}'.format(c)] for u, c in zip(unmapped_space, color_values)] + \
-                             [[1, 'rgb{0}'.format(color_values[-1])]]
-
-                image_info = dict(
-                    z=img,
-                    colorscale=colorscale,
-                    hoverinfo='skip',
-                    xaxis='x',
-                    yaxis='y',
-                    zmin=mapped_bounds[0],
-                    zmax=mapped_bounds[1],
-                    name=layer_state.layer.label,
-                    showscale=False,
-                    showlegend=True,
-                    opacity=layer_state.alpha
-                )
-                layers_to_add.append([fig.add_heatmap, image_info])
-
-        else:
-            img = self.viewer.axes._composite()
-            img[:, :, :3] *= 256
-            image_info = dict(
-                z=img,
-                opacity=1,
-                hoverinfo='skip'
-            )
-            bg_color = img[0][0]
-            fig.update_layout(plot_bgcolor='rgba{0}'.format(tuple(bg_color)))
-            layers_to_add = [[fig.add_image, image_info]]
-
-        for layer in image_subset_layers:
-            layer_state = layer.state
-            ss = layer.layer.subset_state
-            refdata = viewer_state.reference_data
-            if isinstance(ss, PixelSubsetState):
-                try:
-                    x, y = ss.get_xy(layer.layer.data, viewer_state.x_att.axis, viewer_state.y_att.axis)
-                    label = layer_state.layer.label
-                    group = '{0}_{1}'.format(label, legend_groups[label])
-                    legend_groups[label] += 1
-                    line_data = dict(
-                        mode="lines",
-                        marker=dict(
-                            color=layer_state.color
-                        ),
-                        opacity=layer_state.alpha * 0.5,
-                        name=layer_state.layer.label,
-                        legendgroup=group
-                    )
-
-                    x_line_data = {**line_data, 'x': [x, x], 'y': [ymin, ymax], 'showlegend': True}
-                    y_line_data = {**line_data, 'x': [xmin, xmax], 'y': [y, y], 'showlegend': False}
-                    layers_to_add.append([fig.add_scatter, x_line_data])
-                    layers_to_add.append([fig.add_scatter, y_line_data])
-                except IncompatibleAttribute:
-                    pass
-            else:
-                color = 'gray' if layer_state.color == '0.35' else layer_state.color
-                buf = refdata \
-                    .compute_fixed_resolution_buffer(full_view,
-                                                     target_data=refdata,
-                                                     broadcast=False, subset_state=ss)
-                if transpose:
-                    buf = buf.transpose()
-
-                vf = np.vectorize(int)
-                img = vf(buf)
-                rgb_color = to_rgb(color)
-
-                # We use alpha = 0 for the bottom of the colorscale since we don't want
-                # anything outside the subset to contribute
-                colorscale = [[0, 'rgba(0,0,0,0)'], [1, 'rgb{0}'.format(tuple(256 * v for v in rgb_color))]]
-                image_info = dict(
-                    z=img,
-                    colorscale=colorscale,
-                    hoverinfo='skip',
-                    xaxis='x',
-                    yaxis='y',
-                    name=layer_state.layer.label,
-                    opacity=layer_state.alpha * 0.5,
-                    showscale=False,
-                    showlegend=True
-                )
-                layers_to_add.append([fig.add_heatmap, image_info])
-
-        for layer in scatter_layers:
-            layer_state = layer.state
-            x = layer_state.layer[viewer_state.x_att]
-            y = layer_state.layer[viewer_state.y_att]
-
-            marker = {}
-
-            # set all points to be the same color
-            if layer_state.cmap_mode == 'Fixed':
-                if layer_state.color != '0.35':
-                    marker['color'] = layer_state.color
-                else:
-                    marker['color'] = 'gray'
-
-            # color by some attribute
-            else:
-                if layer_state.cmap_vmin > layer_state.cmap_vmax:
-                    cmap = layer_state.cmap.reversed()
-                    norm = Normalize(
-                        vmin=layer_state.cmap_vmax, vmax=layer_state.cmap_vmin)
-                else:
-                    cmap = layer_state.cmap
-                    norm = Normalize(
-                        vmin=layer_state.cmap_vmin, vmax=layer_state.cmap_vmax)
-
-                # most matplotlib colormaps aren't recognized by plotly, so we convert manually to a hex code
-                rgba_list = [
-                    cmap(norm(point)) for point in layer_state.layer[layer_state.cmap_att].copy()]
-                rgb_str = [r'{}'.format(rgb2hex(
-                    (rgba[0], rgba[1], rgba[2]))) for rgba in rgba_list]
-                marker['color'] = rgb_str
-
-            # set all points to be the same size, with some arbitrary scaling
-            if layer_state.size_mode == 'Fixed':
-                marker['size'] = layer_state.size
-
-            # scale size of points by some attribute
-            else:
-                s = ensure_numerical(layer_state.layer[layer_state.size_att].ravel())
-                marker['size'] = 25 * (s - layer_state.size_vmin) / (
-                        layer_state.size_vmax - layer_state.size_vmin)
-                marker['sizemin'] = 1
-                marker['size'][np.isnan(marker['size'])] = 0
-                marker['size'][marker['size'] < 0] = 0
-
-            # set the opacity
-            marker['opacity'] = layer_state.alpha
-
-            # remove default white border around points
-            marker['line'] = dict(width=0)
-
-            # add hover info to layer
-
-            if np.sum(checked_dictionary[layer_state.layer.label]) == 0:
-                hoverinfo = 'skip'
-                hovertext = None
-            else:
-                hoverinfo = 'text'
-                hovertext = ["" for _ in range((layer_state.layer.shape[0]))]
-                for i in range(0, len(layer_state.layer.components)):
-                    if checked_dictionary[layer_state.layer.label][i]:
-                        hover_data = layer_state.layer[layer_state.layer.components[i].label]
-                        for k in range(0, len(hover_data)):
-                            hovertext[k] = (hovertext[k] + "{}: {} <br>"
-                                            .format(layer_state.layer.components[i].label,
-                                                    hover_data[k]))
-
-            # add layer to axesdict
-            scatter_info = dict(
-                mode='markers',
-                marker=marker,
-                xaxis='x',
-                yaxis='y',
-                hoverinfo=hoverinfo,
-                hovertext=hovertext,
-                name=layer_state.layer.label
-            )
-            scatter_info.update(x=x, y=y)
-            layers_to_add.append([fig.add_scatter, scatter_info])
-
-        # This is a hack to force plotly to show the secondary axes, if there are any
-        # We just put in a transparent heatmap assigned to whatever secondary axes exist
-        if secondary_x or secondary_y:
-            secondary_info = dict(z=bg,
-                                  colorscale=[[0, 'rgb(0,0,0)'], [1, 'rgb(0,0,0)']],
-                                  hoverinfo='skip',
-                                  opacity=0,
-                                  showscale=False,
-                                  xaxis='x2' if secondary_x else 'x',
-                                  yaxis='y2' if secondary_y else 'y')
-            layers_to_add.append([fig.add_heatmap, secondary_info])
-
-        for index, (func, data) in enumerate(layers_to_add):
-            func(**data)
+        traces_to_add = traces(self.viewer, secondary_x=secondary_x, secondary_y=secondary_y,
+                               hover_selections=checked_dictionary, add_data_label=add_data_label)
+        for trace in traces_to_add:
+            fig.add_trace(trace)
 
         plot(fig, include_mathjax='cdn', filename=filename, auto_open=False)
 
@@ -402,11 +77,6 @@ class PlotlyImage2DExport(Tool):
                     for component in layer_state.layer.components:
                         data[component.label] = np.ones(10)
                     dc_hover.append(data)
-
-            # figure out which hover info user wants to display
-            for layer in scatter_layers:
-                layer_state = layer.state
-                if layer_state.visible and layer.enabled:
                     checked_dictionary[layer_state.layer.label] = np.zeros((len(layer_state.layer.components))).astype(
                         bool)
 
@@ -419,8 +89,7 @@ class PlotlyImage2DExport(Tool):
         if not filename:
             return
 
-        worker = Worker(self._export_to_plotly, filename, 
-                        layers, checked_dictionary)
+        worker = Worker(self._export_to_plotly, filename, checked_dictionary)
         exp_dialog = export_dialog.ExportDialog(parent=self.viewer)
         worker.result.connect(exp_dialog.close)
         worker.error.connect(exp_dialog.close)


### PR DESCRIPTION
This PR follows the same mold as the previous refactoring PRs, with the image viewer being the viewer of interest this time. The idea is to move the functionality of constructing the exported traces, layout configurations, etc. out to context-independent functions so that we can use them in other export contexts (e.g. the web exporter, glupyter?) in the future, while the export tool handles any Qt-viewer-specific stuff.

The image viewer is easily the most complicated one to export, and does some stuff with secondary axes, so adding this to the web exporter may be nontrivial and can wait for a future PR.