### PR TITLE
Add unit tests for 2D scatter exporter

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -36,7 +36,10 @@ jobs:
         - linux: py39-test
         - linux: py311-test
 
-        - macos: py37-test
+        # Disable Python 3.7 tests on MacOS until https://github.com/actions/setup-python/issues/682
+        # has been resolved
+        # - macos: py37-test
+        - macos: py38-test
         - macos: py310-test
 
         - windows: py38-test

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -38,13 +38,11 @@ def base_layout_config(viewer, **kwargs):
     return config
 
 
-def rectilinear_axis(viewer, axis):
+def base_rectilinear_axis(viewer, axis):
     title = getattr(viewer.axes, f'get_{axis}label')()
     ax = getattr(viewer.axes, f'{axis}axis')
     range = [getattr(viewer.state, f'{axis}_min'), getattr(viewer.state, f'{axis}_max')]
     log = getattr(viewer.state, f'{axis}_log')
-    if log:
-        range = [np.log10(b) for b in range]
     axis_dict = dict(
         title=title,
         titlefont=dict(

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -4,6 +4,8 @@ import numpy as np
 from glue.config import settings
 from glue.core import BaseData
 
+from glue_plotly.utils import opacity_value_string
+
 DEFAULT_FONT = 'Arial, sans-serif'
 
 
@@ -107,8 +109,8 @@ def rgb_colors(layer, mask, cmap_att):
         color_values = color_values[mask]
     rgba_list = np.array([
         cmap(norm(point)) for point in color_values])
-    rgba_list = [[int(256 * t) for t in rgba] for rgba in rgba_list]
-    rgba_strs = [f'rgba({r},{g},{b},{a})' for r, g, b, a in rgba_list]
+    rgba_list = [[int(256 * t) for t in rgba[:3]] + [rgba[3]] for rgba in rgba_list]
+    rgba_strs = [f'rgba({r},{g},{b},{opacity_value_string(a)})' for r, g, b, a in rgba_list]
     return rgba_strs
 
 

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -71,7 +71,8 @@ def base_rectilinear_axis(viewer, axis):
         rangemode='normal',
     )
     if log:
-        axis_dict.update(dtick=1, minor_ticks='outside')
+        axis_dict.update(dtick=1, minor_ticks='outside',
+                         range=list(np.log10(range)))
     return axis_dict
 
 

--- a/glue_plotly/common/histogram.py
+++ b/glue_plotly/common/histogram.py
@@ -3,12 +3,12 @@ from uuid import uuid4
 from glue.core import BaseData
 from plotly.graph_objs import Bar
 
-from glue_plotly.common import base_layout_config, fixed_color, rectilinear_axis
+from glue_plotly.common import base_layout_config, fixed_color, base_rectilinear_axis
 from glue_plotly.utils import ticks_values
 
 
 def axis(viewer, ax, glue_ticks=True):
-    a = rectilinear_axis(viewer, ax)
+    a = base_rectilinear_axis(viewer, ax)
     if glue_ticks:
         vals, text = ticks_values(viewer.axes, ax)
         if vals and text:

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -280,10 +280,12 @@ def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
     if rectilinear:
         if layer_state.xerr_visible:
             xerr, xerr_traces = rectilinear_error_bars(layer, marker, mask, x, y, 'x', legend_group)
-            traces['xerr'] = xerr_traces
+            if xerr_traces:
+                traces['xerr'] = xerr_traces
         if layer_state.yerr_visible:
             yerr, yerr_traces = rectilinear_error_bars(layer, marker, mask, x, y, 'y', legend_group)
-            traces['yerr'] = yerr_traces 
+            if yerr_traces:
+                traces['yerr'] = yerr_traces
 
     if np.sum(hover_data) == 0:
         hoverinfo = 'skip'

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -343,10 +343,10 @@ def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
             x = np.rad2deg(x)
             y = np.rad2deg(y)
         traces['scatter'] = [go.Scattergeo(lon=x, lat=y, projection_type=proj,
-                                    showland=False, showcoastlines=False, showlakes=False,
-                                    lataxis_showgrid=False, lonaxis_showgrid=False,
-                                    bgcolor=settings.BACKGROUND_COLOR,
-                                    framecolor=settings.FOREGROUND_COLOR)]
+                                           showland=False, showcoastlines=False, showlakes=False,
+                                           lataxis_showgrid=False, lonaxis_showgrid=False,
+                                           bgcolor=settings.BACKGROUND_COLOR,
+                                           framecolor=settings.FOREGROUND_COLOR)]
 
     return traces
 

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -22,15 +22,6 @@ def projection_type(viewer):
     return 'azimuthal equal area' if proj == 'lambert' else proj
 
 
-def rectilinear_axis(viewer, axis):
-    ax = base_rectilinear_axis(viewer, axis)
-    helper = getattr(viewer.state, f'{axis}_lim_helper')
-    log = getattr(viewer.state, f'{axis}_log')
-    if log:
-        ax['range'] = [helper.lower, helper.upper]
-    return ax
-
-
 def angular_axis(viewer):
     degrees = viewer.state.using_degrees
     angle_unit = 'degrees' if degrees else 'radians'

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -200,15 +200,15 @@ def rectilinear_2d_vectors(viewer, layer, marker, mask, x, y, legend_group=None)
     if layer_state.cmap_mode == 'Fixed':
         fig = ff.create_quiver(x_vec, y_vec, vx, vy, **vector_info)
         fig.update_traces(marker=dict(color=marker['color']))
-
     else:
         # start with the first quiver to add the rest
+        color = marker['color'] if layer.state.fill else marker['line']['color']
         fig = ff.create_quiver([x[0]], [y[0]], [vx[0]], [vy[0]],
-                               **vector_info, line_color=marker['color'][0])
-        for i in range(1, len(marker['color'])):
+                               **vector_info, line_color=color[0])
+        for i in range(1, len(color)):
             fig1 = ff.create_quiver([x[i]], [y[i]], [vx[i]], [vy[i]],
                                     **vector_info,
-                                    line_color=marker['color'][i])
+                                    line_color=color[i])
             fig.add_traces(data=fig1.data)
 
     return list(fig.data)
@@ -219,7 +219,7 @@ def size_info(layer, mask):
 
     # set all points to be the same size, with some arbitrary scaling
     if state.size_mode == 'Fixed':
-        return 2 * state.size_scaling * state.size
+        return state.size_scaling * state.size
 
     # scale size of points by set size scaling
     else:
@@ -251,16 +251,15 @@ def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
 
     rectilinear = getattr(viewer.state, 'using_rectilinear', True)
 
-    marker = dict(color=color_info(layer, mask),
+    color = color_info(layer, mask)
+    marker = dict(color=color,
                   size=size_info(layer, mask),
                   opacity=layer_state.alpha)
 
     # check whether to fill circles
     if not layer_state.fill:
         marker['color'] = 'rgba(0,0,0,0)'
-        marker['line'] = dict(width=1,
-                              color=layer_state.color)
-
+        marker['line'] = dict(width=1, color=color)
     else:
         # remove default white border around points
         marker['line'] = dict(width=0)
@@ -345,4 +344,4 @@ def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
 
 def traces_for_layer(*args, **kwargs):
     trace_data = trace_data_for_layer(*args, **kwargs)
-    return [trace for traces in trace_data for trace in traces]
+    return [trace for traces in trace_data.values() for trace in traces]

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -10,7 +10,7 @@ from glue.utils import ensure_numerical
 from glue.viewers.scatter.layer_artist import plot_colored_line
 
 from .common import DEFAULT_FONT, base_layout_config,\
-    rectilinear_axis, color_info, dimensions, sanitize
+    base_rectilinear_axis, color_info, dimensions, sanitize
 
 LINESTYLES = {'solid': 'solid', 'dotted': 'dot', 'dashed': 'dash', 'dashdot': 'dashdot'}
 
@@ -18,6 +18,15 @@ LINESTYLES = {'solid': 'solid', 'dotted': 'dot', 'dashed': 'dash', 'dashdot': 'd
 def projection_type(viewer):
     proj = viewer.state.plot_mode
     return 'azimuthal equal area' if proj == 'lambert' else proj
+
+
+def rectilinear_axis(viewer, axis):
+    ax = base_rectilinear_axis(viewer, axis)
+    helper = getattr(viewer.state, f'{axis}_lim_helper')
+    log = getattr(viewer.state, f'{axis}_log')
+    if log:
+        ax['range'] = [helper.lower, helper.upper]
+    return ax
 
 
 def angular_axis(viewer):
@@ -66,8 +75,8 @@ def radial_axis(viewer):
 
 def rectilinear_layout_config(viewer):
     layout_config = base_layout_config(viewer)
-    x_axis = rectilinear_axis(viewer, 'x')
-    y_axis = rectilinear_axis(viewer, 'y')
+    x_axis = base_rectilinear_axis(viewer, 'x')
+    y_axis = base_rectilinear_axis(viewer, 'y')
     layout_config.update(xaxis=x_axis, yaxis=y_axis)
     return layout_config
 
@@ -266,7 +275,8 @@ def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
     line = {}
     if layer_state.line_visible:
         line, mode, line_traces = rectilinear_lines(viewer, layer, marker, x, y, legend_group)
-        traces['line'] = line_traces
+        if line_traces:
+            traces['line'] = line_traces
 
     if rectilinear:
         if layer_state.xerr_visible:

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -9,6 +9,8 @@ from glue.core import BaseData
 from glue.utils import ensure_numerical
 from glue.viewers.scatter.layer_artist import plot_colored_line
 
+from glue_plotly.utils import rgba_string_to_values
+
 from .common import DEFAULT_FONT, base_layout_config,\
     base_rectilinear_axis, color_info, dimensions, sanitize
 
@@ -106,8 +108,9 @@ def rectilinear_lines(viewer, layer, marker, x, y, legend_group=None):
     else:
         # set mode to markers and plot the colored line over it
         mode = 'markers'
-        rgb_strs = marker['color']
-        lc = plot_colored_line(viewer.axes, x, y, rgb_strs)
+        rgba_strs = marker['color']
+        rgba_values = [rgba_string_to_values(s) for s in rgba_strs]
+        lc = plot_colored_line(viewer.axes, x, y, rgba_values)
         segments = lc.get_segments()
         # generate list of indices to parse colors over
         indices = np.repeat(range(len(x)), 2)
@@ -121,7 +124,7 @@ def rectilinear_lines(viewer, layer, marker, x, y, legend_group=None):
                 line=dict(
                     dash=LINESTYLES[layer_state.linestyle],
                     width=layer_state.linewidth,
-                    color=rgb_strs[indices[i]]),
+                    color=rgba_strs[indices[i]]),
                 showlegend=False,
                 hoverinfo='skip')
             )

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -236,6 +236,21 @@ def size_info(layer, mask):
         return s
 
 
+def base_marker(layer, mask):
+    color = color_info(layer, mask)
+    marker = dict(size=size_info(layer, mask),
+                  color=color,
+                  opacity=layer.state.alpha)
+
+    if layer.state.fill:
+        marker['line'] = dict(width=0)
+    else:
+        marker['color'] = 'rgba(0,0,0,0)'
+        marker['line'] = dict(width=1, color=color)
+
+    return marker
+
+
 def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
     traces = {}
     if hover_data is None:
@@ -251,18 +266,7 @@ def trace_data_for_layer(viewer, layer, hover_data=None, add_data_label=True):
 
     rectilinear = getattr(viewer.state, 'using_rectilinear', True)
 
-    color = color_info(layer, mask)
-    marker = dict(color=color,
-                  size=size_info(layer, mask),
-                  opacity=layer_state.alpha)
-
-    # check whether to fill circles
-    if not layer_state.fill:
-        marker['color'] = 'rgba(0,0,0,0)'
-        marker['line'] = dict(width=1, color=color)
-    else:
-        # remove default white border around points
-        marker['line'] = dict(width=0)
+    marker = base_marker(layer, mask)
 
     # add vectors
     if rectilinear and layer.state.vector_visible and layer.state.vector_scaling > 0.1:

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -1,0 +1,122 @@
+from itertools import product
+
+from numpy import nan
+import pytest
+
+from glue.app.qt import GlueApplication
+from glue.config import colormaps, settings
+from glue.core import Data 
+from glue.viewers.scatter.qt import ScatterViewer
+
+from glue_plotly.common.common import DEFAULT_FONT, data_count, layers_to_export, rectilinear_axis
+from glue_plotly.common.scatter2d import traces_for_layer
+
+class TestScatter2D:
+
+    def setup_method(self, method):
+        self.data1 = Data(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9], label='d1')
+        self.data2 = Data(x=[1, 2, 3], y=[1, 4, 9], z=[1, 8, 27], label='d2')
+        self.app = GlueApplication()
+        self.app.session.data_collection.append(self.data1)
+        self.app.session.data_collection.append(self.data2)
+        self.viewer = self.app.new_data_viewer(ScatterViewer)
+        self.viewer.add_data(self.data1)
+        self.viewer.add_data(self.data2)
+        for subtool in self.viewer.toolbar.tools['save'].subtools:
+            if subtool.tool_id == 'save:plotly2d':
+                self.tool = subtool
+                break
+        else:
+            raise Exception("Could not find save:plotly2d tool in viewer")
+
+    def teardown_method(self, method):
+        self.viewer.close(warn=False)
+        self.viewer = None
+        self.app.close()
+        self.app = None
+
+    @pytest.mark.parametrize('log_x, log_y', product([True, False], repeat=2))
+    def test_rectilinear_plot(self, log_x, log_y):
+
+        # Set up viewer state
+        viewer_state = self.viewer.state
+        viewer_state.x_att = 'x'
+        viewer_state.y_att = 'y'
+        viewer_state.x_axislabel = 'X Axis'
+        viewer_state.y_axislabel = 'Y Axis'
+        viewer_state.x_axislabel_size = 12
+        viewer_state.y_axislabel_size = 8
+        viewer_state.x_ticklabel_size = 6
+        viewer_state.y_ticklabel_size = 12
+        viewer_state.x_log = log_x
+        viewer_state.y_log = log_y
+        viewer_state.x_min = 1
+        viewer_state.x_max = 10
+        viewer_state.y_min = 0
+        viewer_state.y_max = 8
+
+        # General viewer items
+        export_layers = layers_to_export(self.viewer)
+        assert len(export_layers) == 2
+        assert data_count(export_layers) == 2
+
+        # Axes
+        x_axis = rectilinear_axis(self.viewer, 'x')
+        y_axis = rectilinear_axis(self.viewer, 'y')
+
+        common_items = dict(showgrid=False, showline=False, mirror=True, rangemode='normal',
+                            zeroline=False, showspikes=False, showticklabels=True,
+                            linecolor=settings.FOREGROUND_COLOR, tickcolor=settings.FOREGROUND_COLOR)
+        assert common_items.items() <= x_axis.items()
+        assert common_items.items() <= y_axis.items()
+
+        assert x_axis['title'] == 'X Axis'
+        assert y_axis['title'] == 'Y Axis'
+        assert x_axis['type'] == 'log' if log_x else 'linear'
+        assert y_axis['type'] == 'log' if log_y else 'linear'
+        assert x_axis['range'] == [1, 10]
+        assert y_axis['range'] == [0, 8]
+
+        base_font_dict = dict(family=DEFAULT_FONT, color=settings.FOREGROUND_COLOR)
+        assert x_axis['titlefont'] == dict(**base_font_dict, size=24)
+        assert y_axis['titlefont'] == dict(**base_font_dict, size=16)
+        assert x_axis['tickfont'] == dict(**base_font_dict, size=9)
+        assert y_axis['tickfont'] == dict(**base_font_dict, size=18)
+
+        if log_x:
+            assert x_axis['dtick'] == 1
+            assert x_axis['minor_ticks'] == 'outside'
+        if log_y:
+            assert y_axis['dtick'] == 1
+            assert y_axis['minor_ticks'] == 'outside'
+
+        layer1 = self.viewer.layers[0]
+        layer1.state.line_visible = True
+        layer1.state.linewidth = 2
+        layer1.state.linestyle = 'dashed'
+        layer1.state.alpha = 0.64
+        layer1.state.xerr_visible = True
+        layer1.state.yerr_visible = True
+        layer1.state.xerr_att = self.data.id['x']
+        layer1.state.yerr_att = self.data.id['y']
+
+        traces1 = traces_for_layer(self.viewer, layer1, hover_data=None, add_data_label=True)
+        assert len(traces1) == 1 + 2 * self.data1.size
+        error_traces = 
+
+
+        
+        layer2 = self.viewer.layers[1]
+        layer2.state.size = 3
+        layer2.state.size_mode = 'Linear'
+        layer2.state.cmap_mode = 'Linear'
+        layer2.state.cmap = colormaps.members[4][1]
+        layer2.state.vector_visible = True
+        layer2.state.vx_att = 'y'
+        layer2.state.vy_att = 'z'
+        layer2.state.vector_arrowhead = True
+        layer2.state.vector_mode = 'Cartesian'
+        layer2.state.vector_origin = 'middle'
+        layer2.state.vector_scaling = 0.5
+
+

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -1,5 +1,6 @@
 from itertools import product
 
+from numpy import log10
 from plotly.graph_objs import Scatter
 import pytest
 
@@ -100,8 +101,14 @@ class TestScatter2DRectilinear(TestScatter2D):
 
         x_lim_helper = self.viewer.state.x_lim_helper
         y_lim_helper = self.viewer.state.y_lim_helper
-        assert x_axis['range'] == [x_lim_helper.lower, x_lim_helper.upper]
-        assert y_axis['range'] == [y_lim_helper.lower, y_lim_helper.upper]
+        expected_x_range = [x_lim_helper.lower, x_lim_helper.upper]
+        expected_y_range = [y_lim_helper.lower, y_lim_helper.upper]
+        if log_x:
+            expected_x_range = list(log10(expected_x_range))
+        if log_y:
+            expected_y_range = list(log10(expected_y_range))
+        assert x_axis['range'] == expected_x_range
+        assert y_axis['range'] == expected_y_range
 
         base_font_dict = dict(family=DEFAULT_FONT, color=settings.FOREGROUND_COLOR)
         assert x_axis['titlefont'] == dict(**base_font_dict, size=24)

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -1,6 +1,7 @@
 from itertools import product
 
 from numpy import nan
+from plotly.graph_objs import Scatter
 import pytest
 
 from glue.app.qt import GlueApplication
@@ -9,7 +10,7 @@ from glue.core import Data
 from glue.viewers.scatter.qt import ScatterViewer
 
 from glue_plotly.common.common import DEFAULT_FONT, data_count, layers_to_export, rectilinear_axis
-from glue_plotly.common.scatter2d import traces_for_layer
+from glue_plotly.common.scatter2d import trace_data_for_layer 
 
 class TestScatter2D:
 
@@ -95,15 +96,19 @@ class TestScatter2D:
         layer1.state.linewidth = 2
         layer1.state.linestyle = 'dashed'
         layer1.state.alpha = 0.64
+        layer.state.color = '#ff0000'
         layer1.state.xerr_visible = True
         layer1.state.yerr_visible = True
         layer1.state.xerr_att = self.data.id['x']
         layer1.state.yerr_att = self.data.id['y']
 
-        traces1 = traces_for_layer(self.viewer, layer1, hover_data=None, add_data_label=True)
-        assert len(traces1) == 1 + 2 * self.data1.size
-        error_traces = 
-
+        traces1 = trace_data_for_layer(self.viewer, layer1, hover_data=None, add_data_label=True)
+        assert set(traces1.keys()) == {'scatter', 'xerr', 'yerr'}
+        scatter1 = traces1['scatter'][0]
+        assert isinstance(scatter1, Scatter) 
+        assert scatter1['mode'] == 'lines+markers'
+        assert scatter1['name'] == 'd1'
+        assert scatter1['marker'] == dict(color='#ff0000', size=6, opacity=0.64)
 
         
         layer2 = self.viewer.layers[1]

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -1,19 +1,18 @@
 from itertools import product
-from glue.core.link_helpers import LinkSame
-from glue.core.visual import cmap
 
-import numpy as np
-from matplotlib import colormaps
 from plotly.graph_objs import Scatter
 import pytest
 
 from glue.app.qt import GlueApplication
 from glue.config import settings
-from glue.core import Data 
+from glue.core import Data
 from glue.viewers.scatter.qt import ScatterViewer
 
-from glue_plotly.common.common import DEFAULT_FONT, color_info, data_count, layers_to_export, base_rectilinear_axis, sanitize
-from glue_plotly.common.scatter2d import base_marker, rectilinear_2d_vectors, rectilinear_error_bars, rectilinear_lines, trace_data_for_layer 
+from glue_plotly.common.common import DEFAULT_FONT, color_info, data_count, layers_to_export, \
+                                      base_rectilinear_axis, sanitize
+from glue_plotly.common.scatter2d import base_marker, rectilinear_2d_vectors, rectilinear_error_bars, \
+                                         rectilinear_lines, trace_data_for_layer
+
 
 class TestScatter2D:
 
@@ -38,7 +37,7 @@ class TestScatter2D:
 
 
 class TestScatter2DRectilinear(TestScatter2D):
-    
+
     def setup_method(self, method):
         super().setup_method(method)
 
@@ -98,7 +97,7 @@ class TestScatter2DRectilinear(TestScatter2D):
         assert y_axis['title'] == 'Y Axis'
         assert x_axis['type'] == 'log' if log_x else 'linear'
         assert y_axis['type'] == 'log' if log_y else 'linear'
-        
+
         x_lim_helper = self.viewer.state.x_lim_helper
         y_lim_helper = self.viewer.state.y_lim_helper
         assert x_axis['range'] == [x_lim_helper.lower, x_lim_helper.upper]
@@ -116,7 +115,6 @@ class TestScatter2DRectilinear(TestScatter2D):
         if log_y:
             assert y_axis['dtick'] == 1
             assert y_axis['minor_ticks'] == 'outside'
-
 
     @pytest.mark.parametrize('fill', [True, False])
     def test_base_marker(self, fill):
@@ -136,13 +134,13 @@ class TestScatter2DRectilinear(TestScatter2D):
         self.layer.state.xerr_visible = True
         self.layer.state.yerr_visible = True
         marker = base_marker(self.layer, self.mask)
-        xerr, xerr_traces = rectilinear_error_bars(self.layer, marker, self.mask, self.x, self.y, 'x') 
+        xerr, xerr_traces = rectilinear_error_bars(self.layer, marker, self.mask, self.x, self.y, 'x')
         yerr, yerr_traces = rectilinear_error_bars(self.layer, marker, self.mask, self.x, self.y, 'y')
 
         mask_size = sum(self.mask)
         assert len(xerr['array']) == mask_size
         assert len(yerr['array']) == mask_size
-        
+
         color = color_info(self.layer, self.mask)
         for traces in [xerr_traces, yerr_traces]:
             for i, bar in enumerate(traces):
@@ -159,13 +157,13 @@ class TestScatter2DRectilinear(TestScatter2D):
         self.layer.state.xerr_visible = True
         self.layer.state.yerr_visible = True
         marker = base_marker(self.layer, self.mask)
-        xerr, xerr_traces = rectilinear_error_bars(self.layer, marker, self.mask, self.x, self.y, 'x') 
+        xerr, xerr_traces = rectilinear_error_bars(self.layer, marker, self.mask, self.x, self.y, 'x')
         yerr, yerr_traces = rectilinear_error_bars(self.layer, marker, self.mask, self.x, self.y, 'y')
 
         mask_size = sum(self.mask)
         assert len(xerr['array']) == mask_size
         assert len(yerr['array']) == mask_size
-        
+
         assert len(xerr_traces) == 0
         assert len(yerr_traces) == 0
 
@@ -177,7 +175,7 @@ class TestScatter2DRectilinear(TestScatter2D):
         marker = base_marker(self.layer, self.mask)
         line, mode, traces = rectilinear_lines(self.viewer, self.layer, marker, self.x, self.y)
         assert mode == "lines+markers"
-        assert line['dash'] == "dash" 
+        assert line['dash'] == "dash"
         assert line['width'] == 4
         assert len(traces) == 0
 
@@ -206,8 +204,6 @@ class TestScatter2DRectilinear(TestScatter2D):
         self.layer.state.vector_arrowhead = True
         self.layer.state.cmap_mode = cmap_mode
 
-        vx = self.layer.state.layer[self.layer.state.vx_att][self.mask]
-        vy = self.layer.state.layer[self.layer.state.vy_att][self.mask]
         marker = base_marker(self.layer, self.mask)
         traces = rectilinear_2d_vectors(self.viewer, self.layer, marker, self.mask, self.x, self.y)
         color = color_info(self.layer, self.mask)
@@ -228,8 +224,7 @@ class TestScatter2DRectilinear(TestScatter2D):
         hover_components = [self.data.id['x'], self.data.id['z']]
         hover_data = [cid in hover_components for cid in self.layer.layer.components]
         traces = trace_data_for_layer(self.viewer, self.layer, hover_data=hover_data, add_data_label=True)
-        assert(set(traces.keys())) == {'scatter', 'vector'}
+        assert set(traces.keys()) == {'scatter', 'vector'}
         scatter = traces['scatter'][0]
         assert scatter['hoverinfo'] == 'text'
         assert len(scatter['hovertext']) == len(self.layer.layer.main_components)
-

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -1,12 +1,13 @@
 from itertools import product
 from glue.core.link_helpers import LinkSame
 
+from matplotlib import colormaps
 from numpy import log10 
 from plotly.graph_objs import Scatter
 import pytest
 
 from glue.app.qt import GlueApplication
-from glue.config import colormaps, settings
+from glue.config import settings
 from glue.core import Data 
 from glue.viewers.scatter.qt import ScatterViewer
 
@@ -121,7 +122,8 @@ class TestScatter2D:
         layer2.state.size = 3
         layer2.state.size_mode = 'Linear'
         layer2.state.cmap_mode = 'Linear'
-        layer2.state.cmap = colormaps.members[4][1]
+        layer2.state.alpha = 0.9
+        layer2.state.cmap = colormaps.get_cmap('magma')
         layer2.state.vector_visible = True
         layer2.state.vx_att = self.data2.id['y']
         layer2.state.vy_att = self.data2.id['z']
@@ -130,5 +132,14 @@ class TestScatter2D:
         layer2.state.vector_mode = 'Cartesian'
         layer2.state.vector_origin = 'middle'
         layer2.state.vector_scaling = 0.5
+
+        hover_components = [self.data2.id['x'], self.data2.id['y']]
+        hover_data = [cid in hover_components for cid in layer2.layer.components]
+        traces2 = trace_data_for_layer(self.viewer, layer2, hover_data=hover_data, add_data_label=True)
+        assert set(traces2.keys()) == {'scatter', 'vector'}
+        scatter2 = traces2['scatter'][0]
+        assert isinstance(scatter2, Scatter)
+        assert scatter2['mode'] == 'markers'
+        assert scatter2['name'] == 'd2'
 
 

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -131,7 +131,7 @@ class TestScatter2DRectilinear(TestScatter2D):
             assert marker['color'] == 'rgba(0,0,0,0)'
             assert marker['line'] == dict(width=1, color="#ff0000")
 
-    def test_rectilinear_error_bars_linear(self):
+    def test_rectilinear_error_bars_cmap(self):
         self.layer.state.cmap_mode = 'Linear'
         self.layer.state.xerr_visible = True
         self.layer.state.yerr_visible = True
@@ -154,7 +154,7 @@ class TestScatter2DRectilinear(TestScatter2D):
                 assert bar['hovertext'] is None
                 assert bar['marker']['color'] == color[i]
 
-    def test_rectilinear_error_bars_fixed(self):
+    def test_rectilinear_error_bars_fixed_color(self):
         self.layer.state.cmap_mode = 'Fixed'
         self.layer.state.xerr_visible = True
         self.layer.state.yerr_visible = True
@@ -169,7 +169,7 @@ class TestScatter2DRectilinear(TestScatter2D):
         assert len(xerr_traces) == 0
         assert len(yerr_traces) == 0
 
-    def test_rectilinear_lines_fixed(self):
+    def test_rectilinear_lines_fixed_color(self):
         self.layer.state.cmap_mode = "Fixed"
         self.layer.state.line_visible = True
         self.layer.state.linestyle = 'dashed'
@@ -181,7 +181,7 @@ class TestScatter2DRectilinear(TestScatter2D):
         assert line['width'] == 4
         assert len(traces) == 0
 
-    def test_rectilinear_lines_linear(self):
+    def test_rectilinear_lines_cmap(self):
         self.layer.state.cmap_mode = "Linear"
         self.layer.state.line_visible = True
         self.layer.state.linestyle = "dotted"

--- a/glue_plotly/utils.py
+++ b/glue_plotly/utils.py
@@ -1,4 +1,4 @@
-from re import sub
+from re import match, sub
 
 __all__ = ['cleaned_labels', 'ticks_values']
 
@@ -28,3 +28,22 @@ def ticks_values(axes, axis):
             text.append(txt)
         text = cleaned_labels(text)
     return vals, text
+
+
+def opacity_value_string(a):
+    asint = int(a)
+    asfloat = float(a)
+    n = asint if asint == asfloat else asfloat
+    return str(n)
+
+
+DECIMAL_PATTERN = "\\d+\\.?\\d*"
+RGBA_PATTERN = f"rgba\\(({DECIMAL_PATTERN}),\\s*({DECIMAL_PATTERN}),\\s*({DECIMAL_PATTERN}),\\s*({DECIMAL_PATTERN})\\)"
+
+
+def rgba_string_to_values(rgba_str):
+    m = match(RGBA_PATTERN, rgba_str)
+    if not m or len(m.groups()) != 4:
+        raise ValueError("Invalid RGBA expression")
+    r, g, b, a = m.groups()
+    return [r, g, b, a]

--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -8,7 +8,7 @@ except ImportError:
 from glue.core.layout import Rectangle, snap_to_grid
 
 from glue_plotly.common import histogram, profile, scatter2d, \
-    data_count, layers_to_export, rectilinear_axis
+    data_count, layers_to_export, base_rectilinear_axis
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -105,8 +105,8 @@ def export_scatter(viewer):
     for layer in layers:
         traces += scatter2d.traces_for_layer(viewer, layer, add_data_label=add_data_label)
 
-    xaxis = rectilinear_axis(viewer, 'x')
-    yaxis = rectilinear_axis(viewer, 'y')
+    xaxis = base_rectilinear_axis(viewer, 'x')
+    yaxis = base_rectilinear_axis(viewer, 'y')
 
     return traces, xaxis, yaxis
 

--- a/glue_plotly/web/qt/tests/test_plotly.py
+++ b/glue_plotly/web/qt/tests/test_plotly.py
@@ -64,7 +64,7 @@ class TestPlotly(object):
         data = args[0]['data'][0].to_plotly_json()
 
         expected = dict(type='scatter', mode='markers', name=d.label,
-                        marker=dict(size=12, opacity=0.4,
+                        marker=dict(size=6, opacity=0.4,
                                     color="#ff0000",
                                     line=dict(width=0)))
         for k, v in expected.items():


### PR DESCRIPTION
This PR adds some unit tests for the 2D scatter exporter, as well as fixes some issues that were found during the creation of these tests. The tests here are relatively straightforward and confirm that the generated Plotly traces have the expected properties. More PRs to come with similar tests for the other viewer types.