### PR TITLE
Add basic tests for histogram and profile export

### DIFF
--- a/glue_plotly/common/histogram.py
+++ b/glue_plotly/common/histogram.py
@@ -55,10 +55,11 @@ def traces_for_layer(viewer, layer, add_data_label=True):
             )
             traces.append(Bar(**hist_info))
     else:
+        width = edges[1] - edges[0]
         hist_info.update(
             x=x,
             y=y,
-            width=edges[1] - edges[0],
+            width=width,
         )
         traces.append(Bar(**hist_info))
 

--- a/glue_plotly/common/tests/test_histogram.py
+++ b/glue_plotly/common/tests/test_histogram.py
@@ -1,0 +1,115 @@
+from itertools import product
+
+from numpy import log10
+from plotly.graph_objs import Bar
+import pytest
+
+from glue.app.qt import GlueApplication
+from glue.config import settings
+from glue.core import Data
+from glue.viewers.histogram.qt import HistogramViewer
+
+from glue_plotly.common import DEFAULT_FONT, data_count, layers_to_export, sanitize
+from glue_plotly.common.histogram import axis, traces_for_layer
+
+
+class TestHistogram:
+
+    def setup_method(self, method):
+        self.data = Data(label="histogram", x=[3.4, -2.3, -1.1, 0.3])
+        self.app = GlueApplication()
+        self.app.session.data_collection.append(self.data)
+        self.viewer = self.app.new_data_viewer(HistogramViewer)
+        self.viewer.add_data(self.data)
+        self.mask, self.sanitized = sanitize(self.data['x'])
+
+        viewer_state = self.viewer.state
+        viewer_state.x_axislabel_size = 14
+        viewer_state.y_axislabel_size = 8
+        viewer_state.x_ticklabel_size = 18
+        viewer_state.y_ticklabel_size = 20
+        viewer_state.x_min = 1
+        viewer_state.x_max = 250
+        viewer_state.y_min = 0
+        viewer_state.y_max = 5
+        viewer_state.x_axislabel = 'X Axis'
+        viewer_state.y_axislabel = 'Y Axis'
+
+        self.layer = self.viewer.layers[0]
+        self.layer.state.color = '#0e1dab'
+        self.layer.state.alpha = 0.85
+
+    def teardown_method(self, method):
+        self.viewer.close(warn=False)
+        self.viewer = None
+        self.app.close()
+        self.app = None
+
+    def test_basic(self):
+        export_layers = layers_to_export(self.viewer)
+        assert len(export_layers) == 1
+        assert data_count(export_layers) == 1
+        assert sum(self.mask) == 4
+
+    @pytest.mark.parametrize('log_x, log_y', product([True, False], repeat=2))
+    def test_axes(self, log_x, log_y):
+        self.viewer.state.x_log = log_x
+        self.viewer.state.y_log = log_y
+        self.viewer.state.x_axislabel = 'X Axis'
+        self.viewer.state.y_axislabel = 'Y Axis'
+
+        x_axis = axis(self.viewer, 'x')
+        y_axis = axis(self.viewer, 'y')
+
+        common_items = dict(showgrid=False, showline=True, mirror=True, rangemode='normal',
+                            zeroline=False, showspikes=False, showticklabels=True,
+                            linecolor=settings.FOREGROUND_COLOR, tickcolor=settings.FOREGROUND_COLOR)
+        assert common_items.items() <= x_axis.items()
+        assert common_items.items() <= y_axis.items()
+
+        assert x_axis['title'] == 'X Axis'
+        assert y_axis['title'] == 'Y Axis'
+        assert x_axis['type'] == 'log' if log_x else 'linear'
+        assert y_axis['type'] == 'log' if log_y else 'linear'
+
+        expected_x_range = [self.viewer.state.x_min, self.viewer.state.x_max]
+        expected_y_range = [self.viewer.state.y_min, self.viewer.state.y_max]
+        if log_x:
+            expected_x_range = list(log10(expected_x_range))
+        if log_y:
+            expected_y_range = list(log10(expected_y_range))
+        assert x_axis['range'] == expected_x_range
+        assert y_axis['range'] == expected_y_range
+
+        base_font_dict = dict(family=DEFAULT_FONT, color=settings.FOREGROUND_COLOR)
+        assert x_axis['titlefont'] == dict(**base_font_dict, size=28)
+        assert y_axis['titlefont'] == dict(**base_font_dict, size=16)
+        assert x_axis['tickfont'] == dict(**base_font_dict, size=27)
+        assert y_axis['tickfont'] == dict(**base_font_dict, size=30)
+
+        if log_x:
+            assert x_axis['dtick'] == 1
+            assert x_axis['minor_ticks'] == 'outside'
+        if log_y:
+            assert y_axis['dtick'] == 1
+            assert y_axis['minor_ticks'] == 'outside'
+
+    def test_basic_trace(self):
+        traces = traces_for_layer(self.viewer, self.layer)
+        assert len(traces) == 1
+        trace = traces[0]
+        assert isinstance(trace, Bar)
+        edges, _ = self.layer.state.histogram
+        assert trace['width'] == edges[1] - edges[0]
+
+    def test_log_trace(self):
+        self.viewer.state.x_log = True
+        self.viewer.state.hist_n_bin = 3
+        edges, _ = self.layer.state.histogram
+        traces = traces_for_layer(self.viewer, self.layer)
+        assert len(traces) == len(edges) - 1
+        legend_group = traces[0]['legendgroup']
+        for index, trace in enumerate(traces):
+            assert trace['legendgroup'] == legend_group
+            assert trace['showlegend'] == (index == 0)
+            assert trace['width'] == edges[index + 1] - edges[index]

--- a/glue_plotly/common/tests/test_profile.py
+++ b/glue_plotly/common/tests/test_profile.py
@@ -1,0 +1,114 @@
+from itertools import product
+
+from numpy import arange, log10
+from glue_plotly.common.common import DEFAULT_FONT
+import pytest
+
+from glue.app.qt import GlueApplication
+from glue.config import settings
+from glue.core import Data
+from glue.viewers.profile.qt import ProfileViewer
+
+from glue_plotly.common import data_count, layers_to_export, sanitize
+from glue_plotly.common.profile import axis, traces_for_layer
+
+from .utils import SimpleCoordinates
+
+
+class TestProfile:
+
+    def setup_method(self, method):
+        self.data = Data(label='profile', w=arange(0, 240, 10).reshape((3, 4, 2)).astype(float))
+        self.data.coords = SimpleCoordinates()
+        self.app = GlueApplication()
+        self.app.session.data_collection.append(self.data)
+        self.viewer = self.app.new_data_viewer(ProfileViewer)
+        self.viewer.add_data(self.data)
+        self.mask, self.sanitized = sanitize(self.data['w'])
+
+        viewer_state = self.viewer.state
+        viewer_state.x_axislabel_size = 15
+        viewer_state.y_axislabel_size = 10
+        viewer_state.x_ticklabel_size = 6
+        viewer_state.y_ticklabel_size = 12
+        viewer_state.x_min = 1
+        viewer_state.x_max = 250
+        viewer_state.y_min = 0
+        viewer_state.y_max = 5
+        viewer_state.x_axislabel = 'X Axis'
+        viewer_state.y_axislabel = 'Y Axis'
+
+        self.layer = self.viewer.layers[0]
+        self.layer.state.linewidth = 3
+        self.layer.state.as_steps = False
+        self.layer.state.color = '#ff0000'
+        self.layer.state.alpha = 0.75
+
+    def teardown_method(self, method):
+        self.viewer.close(warn=False)
+        self.viewer = None
+        self.app.close()
+        self.app = None
+
+    def test_basic(self):
+        export_layers = layers_to_export(self.viewer)
+        assert len(export_layers) == 1
+        assert data_count(export_layers) == 1
+        assert sum(sum(sum(self.mask))) == 24
+
+    @pytest.mark.parametrize('log_x, log_y', product([True, False], repeat=2))
+    def test_axes(self, log_x, log_y):
+        self.viewer.state.x_log = log_x
+        self.viewer.state.y_log = log_y
+        self.viewer.state.x_axislabel = 'X Axis'
+        self.viewer.state.y_axislabel = 'Y Axis'
+
+        x_axis = axis(self.viewer, 'x')
+        y_axis = axis(self.viewer, 'y')
+
+        common_items = dict(showgrid=False, showline=True, mirror=True, rangemode='normal',
+                            zeroline=False, showspikes=False, showticklabels=True,
+                            linecolor=settings.FOREGROUND_COLOR, tickcolor=settings.FOREGROUND_COLOR)
+        assert common_items.items() <= x_axis.items()
+        assert common_items.items() <= y_axis.items()
+
+        assert x_axis['title'] == 'X Axis'
+        assert y_axis['title'] == 'Y Axis'
+        assert x_axis['type'] == 'log' if log_x else 'linear'
+        assert y_axis['type'] == 'log' if log_y else 'linear'
+
+        expected_x_range = [self.viewer.state.x_min, self.viewer.state.x_max]
+        expected_y_range = [self.viewer.state.y_min, self.viewer.state.y_max]
+        if log_x:
+            expected_x_range = list(log10(expected_x_range))
+        if log_y:
+            expected_y_range = list(log10(expected_y_range))
+        assert x_axis['range'] == expected_x_range
+        assert y_axis['range'] == expected_y_range
+
+        base_font_dict = dict(family=DEFAULT_FONT, color=settings.FOREGROUND_COLOR)
+        assert x_axis['titlefont'] == dict(**base_font_dict, size=30)
+        assert y_axis['titlefont'] == dict(**base_font_dict, size=20)
+        assert x_axis['tickfont'] == dict(**base_font_dict, size=9)
+        assert y_axis['tickfont'] == dict(**base_font_dict, size=18)
+
+        if log_x:
+            assert x_axis['dtick'] == 1
+            assert x_axis['minor_ticks'] == 'outside'
+        if log_y:
+            assert y_axis['dtick'] == 1
+            assert y_axis['minor_ticks'] == 'outside'
+
+    @pytest.mark.parametrize('as_steps', [True, False])
+    def test_trace(self, as_steps):
+        self.layer.state.as_steps = as_steps
+        traces = traces_for_layer(self.viewer, self.layer, add_data_label=False)
+        assert len(traces) == 1
+        trace = traces[0]
+        line = trace['line']
+        assert line['width'] == 6
+        assert line['shape'] == 'hvh' if as_steps else 'linear'
+        assert line['color'] == '#ff0000'
+        assert trace['opacity'] == 0.75
+        assert trace['name'] == 'profile'
+        assert trace['hoverinfo'] == 'skip'

--- a/glue_plotly/common/tests/test_profile.py
+++ b/glue_plotly/common/tests/test_profile.py
@@ -1,7 +1,6 @@
 from itertools import product
 
 from numpy import arange, log10
-from glue_plotly.common.common import DEFAULT_FONT
 import pytest
 
 from glue.app.qt import GlueApplication
@@ -9,10 +8,10 @@ from glue.config import settings
 from glue.core import Data
 from glue.viewers.profile.qt import ProfileViewer
 
-from glue_plotly.common import data_count, layers_to_export, sanitize
+from glue_plotly.common import DEFAULT_FONT, data_count, layers_to_export, sanitize
 from glue_plotly.common.profile import axis, traces_for_layer
 
-from .utils import SimpleCoordinates
+from glue_plotly.common.tests.utils import SimpleCoordinates
 
 
 class TestProfile:
@@ -102,7 +101,7 @@ class TestProfile:
     @pytest.mark.parametrize('as_steps', [True, False])
     def test_trace(self, as_steps):
         self.layer.state.as_steps = as_steps
-        traces = traces_for_layer(self.viewer, self.layer, add_data_label=False)
+        traces = traces_for_layer(self.viewer, self.layer)
         assert len(traces) == 1
         trace = traces[0]
         line = trace['line']

--- a/glue_plotly/common/tests/test_scatter2d.py
+++ b/glue_plotly/common/tests/test_scatter2d.py
@@ -9,7 +9,7 @@ from glue.config import settings
 from glue.core import Data
 from glue.viewers.scatter.qt import ScatterViewer
 
-from glue_plotly.common.common import DEFAULT_FONT, color_info, data_count, layers_to_export, \
+from glue_plotly.common import DEFAULT_FONT, color_info, data_count, layers_to_export, \
                                       base_rectilinear_axis, sanitize
 from glue_plotly.common.scatter2d import base_marker, rectilinear_2d_vectors, rectilinear_error_bars, \
                                          rectilinear_lines, trace_data_for_layer
@@ -23,12 +23,6 @@ class TestScatter2D:
         self.app.session.data_collection.append(self.data)
         self.viewer = self.app.new_data_viewer(ScatterViewer)
         self.viewer.add_data(self.data)
-        for subtool in self.viewer.toolbar.tools['save'].subtools:
-            if subtool.tool_id == 'save:plotly2d':
-                self.tool = subtool
-                break
-        else:
-            raise Exception("Could not find save:plotly2d tool in viewer")
 
     def teardown_method(self, method):
         self.viewer.close(warn=False)

--- a/glue_plotly/common/tests/utils.py
+++ b/glue_plotly/common/tests/utils.py
@@ -1,0 +1,22 @@
+from numpy import zeros
+
+from glue.core import Coordinates
+
+
+class SimpleCoordinates(Coordinates):
+
+    def __init__(self):
+        super().__init__(pixel_n_dim=3, world_n_dim=3)
+
+    def pixel_to_world_values(self, *args):
+        return tuple([2.0 * p for p in args])
+
+    def world_to_pixel_values(self, *args):
+        return tuple([0.5 * w for w in args])
+
+    @property
+    def axis_correlation_matrix(self):
+        matrix = zeros((self.world_n_dim, self.pixel_n_dim), dtype=bool)
+        matrix[2, 2] = True
+        matrix[0:2, 0:2] = True
+        return matrix

--- a/glue_plotly/web/qt/tests/test_plotly.py
+++ b/glue_plotly/web/qt/tests/test_plotly.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import numpy as np
 
-from glue.core import Coordinates, Data, DataCollection
+from glue.core import Data, DataCollection
 
 pytest.importorskip('qtpy')
 
@@ -13,25 +13,7 @@ from glue.viewers.histogram.qt import HistogramViewer  # noqa: E402
 from glue.viewers.profile.qt import ProfileViewer  # noqa: E402
 
 from ...export_plotly import build_plotly_call  # noqa: E402
-
-
-class SimpleCoordinates(Coordinates):
-
-    def __init__(self):
-        super().__init__(pixel_n_dim=3, world_n_dim=3)
-
-    def pixel_to_world_values(self, *args):
-        return tuple([2.0 * p for p in args])
-
-    def world_to_pixel_values(self, *args):
-        return tuple([0.5 * w for w in args])
-
-    @property
-    def axis_correlation_matrix(self):
-        matrix = np.zeros((self.world_n_dim, self.pixel_n_dim), dtype=bool)
-        matrix[2, 2] = True
-        matrix[0:2, 0:2] = True
-        return matrix
+from ....common.tests.utils import SimpleCoordinates  # noqa: E402
 
 
 class TestPlotly(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310}-test
+envlist = py{36,37,38,39,310,311}-test
 requires = pip >= 18.0
            setuptools >= 30.3.0
 


### PR DESCRIPTION
Similar to #36, this PR adds some unit tests for the histogram and profile export functionality. These are the simplest exporters, so these tests are pretty simple.