### PR TITLE
Add exporter for dendrogram viewer

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -46,6 +46,16 @@ def setup():
     TableViewer.tools += ['save:plotlytable']
 
     try:
+        from glue.plugins.dendro_viewer.qt import DendrogramViewer
+    except ImportError:
+        pass
+    else:
+        DendrogramViewer.subtools = {
+            **DendrogramViewer.subtools,
+            "save": DendrogramViewer.subtools["save"] + ['save:plotlydendro']
+        }
+
+    try:
         from glue_vispy_viewers.scatter.scatter_viewer import VispyScatterViewer
     except ImportError:
         pass

--- a/glue_plotly/common/__init__.py
+++ b/glue_plotly/common/__init__.py
@@ -1,3 +1,4 @@
 from .common import *  # noqa
+from . import dendrogram  # noqa
 from . import histogram  # noqa
 from . import scatter2d  # noqa

--- a/glue_plotly/common/dendrogram.py
+++ b/glue_plotly/common/dendrogram.py
@@ -1,0 +1,37 @@
+from glue.core import BaseData
+from glue_plotly.common import base_layout_config, base_rectilinear_axis, fixed_color
+
+from plotly.graph_objs import Scatter
+
+
+def x_axis(viewer):
+    return dict(
+        showticklabels=False,
+        showline=False,
+        showgrid=False,
+        range=[viewer.state.x_min, viewer.state.x_max]
+    )
+
+
+def layout_config(viewer):
+    config = base_layout_config(viewer)
+    xaxis = x_axis(viewer)
+    yaxis = base_rectilinear_axis(viewer, 'y')
+    config.update(xaxis=xaxis, yaxis=yaxis)
+    return config
+
+
+def trace_for_layer(layer, data, add_data_label=True):
+    name = layer.layer.label
+    if add_data_label and not isinstance(layer.layer, BaseData):
+        name += " ({0})".format(layer.layer.data.label)
+    return Scatter(
+        mode='lines',
+        x=data[:, 0],
+        y=data[:, 1],
+        name=name,
+        hoverinfo='skip',
+        line=dict(width=layer.state.linewidth,
+                  color=fixed_color(layer)),
+        opacity=layer.state.alpha
+    )

--- a/glue_plotly/common/dendrogram.py
+++ b/glue_plotly/common/dendrogram.py
@@ -31,7 +31,7 @@ def trace_for_layer(layer, data, add_data_label=True):
         y=data[:, 1],
         name=name,
         hoverinfo='skip',
-        line=dict(width=layer.state.linewidth,
+        line=dict(width=1.5 * layer.state.linewidth,
                   color=fixed_color(layer)),
         opacity=layer.state.alpha
     )

--- a/glue_plotly/common/tests/test_dendrogram.py
+++ b/glue_plotly/common/tests/test_dendrogram.py
@@ -72,5 +72,5 @@ class TestDendrogram:
         assert trace['hoverinfo'] == 'skip'
         assert trace['opacity'] == 0.86
         line = trace['line']
-        assert line['width'] == 4
+        assert line['width'] == 6
         assert line['color'] == '#729fcf'

--- a/glue_plotly/common/tests/test_dendrogram.py
+++ b/glue_plotly/common/tests/test_dendrogram.py
@@ -1,0 +1,76 @@
+from numpy import log10
+from plotly.graph_objs import Scatter
+import pytest
+
+from glue.app.qt import GlueApplication
+from glue.config import settings
+from glue.core import Data
+from glue.plugins.dendro_viewer.qt import DendrogramViewer
+
+from glue_plotly.common import data_count, layers_to_export
+from glue_plotly.common.common import base_rectilinear_axis
+from glue_plotly.common.dendrogram import trace_for_layer, x_axis
+
+
+class TestDendrogram:
+
+    def setup_method(self, method):
+        self.data = Data(label='dendrogram', parent=[-1, 0, 1, 1], height=[1.3, 2.2, 3.2, 4.4])
+        self.app = GlueApplication()
+        self.app.session.data_collection.append(self.data)
+        self.viewer = self.app.new_data_viewer(DendrogramViewer)
+        self.viewer.add_data(self.data)
+
+        self.layer = self.viewer.layers[0]
+        self.layer.state.linewidth = 4
+        self.layer.state.alpha = 0.86
+        self.layer.state.color = '#729fcf'
+
+    def teardown_method(self, method):
+        self.viewer.close(warn=False)
+        self.viewer = None
+        self.app.close()
+        self.app = None
+
+    def test_basic(self):
+        export_layers = layers_to_export(self.viewer)
+        assert len(export_layers) == 1
+        assert data_count(export_layers) == 1
+
+    @pytest.mark.parametrize('log_y', [True, False])
+    def test_axes(self, log_y):
+        self.viewer.state.y_log = log_y
+
+        xaxis = x_axis(self.viewer)
+        yaxis = base_rectilinear_axis(self.viewer, 'y')
+
+        assert xaxis['showticklabels'] is False
+        assert xaxis['showline'] is False
+        assert xaxis['showgrid'] is False
+        assert xaxis['range'] == [self.viewer.state.x_min, self.viewer.state.x_max]
+
+        default_settings = dict(showgrid=False, showline=True, mirror=True, rangemode='normal',
+                                zeroline=False, showspikes=False, showticklabels=True,
+                                linecolor=settings.FOREGROUND_COLOR, tickcolor=settings.FOREGROUND_COLOR)
+        assert default_settings.items() <= yaxis.items()
+
+        assert yaxis['type'] == 'log' if log_y else 'linear'
+        expected_y_range = [self.viewer.state.y_min, self.viewer.state.y_max]
+        if log_y:
+            expected_y_range = list(log10(expected_y_range))
+        assert yaxis['range'] == expected_y_range
+        if log_y:
+            assert yaxis['dtick'] == 1
+            assert yaxis['minor_ticks'] == 'outside'
+
+    def test_trace(self):
+        xy_data = self.layer.mpl_artists[0].get_xydata()
+        trace = trace_for_layer(self.layer, xy_data)
+        assert isinstance(trace, Scatter)
+        assert trace['mode'] == 'lines'
+        assert trace['name'] == 'dendrogram'
+        assert trace['hoverinfo'] == 'skip'
+        assert trace['opacity'] == 0.86
+        line = trace['line']
+        assert line['width'] == 4
+        assert line['color'] == '#729fcf'

--- a/glue_plotly/html_exporters/__init__.py
+++ b/glue_plotly/html_exporters/__init__.py
@@ -4,3 +4,4 @@ from . import image # noqa
 from . import histogram  # noqa
 from . import profile  # noqa
 from . import table  # noqa
+from . import dendrogram  # noqa

--- a/glue_plotly/html_exporters/dendrogram.py
+++ b/glue_plotly/html_exporters/dendrogram.py
@@ -1,0 +1,45 @@
+from qtpy import compat
+
+from glue.config import viewer_tool
+from glue.utils.qt import messagebox_on_error
+
+try:
+    from glue.viewers.common.qt.tool import Tool
+except ImportError:
+    from glue.viewers.common.tool import Tool
+
+from glue_plotly import PLOTLY_ERROR_MESSAGE, PLOTLY_LOGO
+from glue_plotly.common import data_count, layers_to_export
+from glue_plotly.common.dendrogram import layout_config, trace_for_layer
+
+from plotly.offline import plot
+import plotly.graph_objs as go
+
+
+@viewer_tool
+class PlotlyDendrogramStaticExport(Tool):
+    icon = PLOTLY_LOGO
+    tool_id = 'save:plotlydendro'
+    action_text = 'Save Plotly HTML page'
+    tool_tip = 'Save Plotly HTML page'
+
+    @messagebox_on_error(PLOTLY_ERROR_MESSAGE)
+    def activate(self):
+
+        filename, _ = compat.getsavefilename(parent=self.viewer, basedir="plot.html")
+        if not filename:
+            return
+
+        layers = layers_to_export(self.viewer)
+        add_data_label = data_count(layers) > 1
+
+        config = layout_config(self.viewer)
+        layout = go.Layout(**config)
+        fig = go.Figure(layout=layout)
+
+        for layer in layers:
+            data = layer.mpl_artists[0].get_xydata()
+            trace = trace_for_layer(layer, data, add_data_label=add_data_label)
+            fig.add_trace(trace)
+
+        plot(fig, filename=filename, auto_open=False)

--- a/glue_plotly/html_exporters/tests/test_dendrogram.py
+++ b/glue_plotly/html_exporters/tests/test_dendrogram.py
@@ -1,0 +1,40 @@
+import os
+
+from mock import patch
+
+from glue.core import Data
+from glue.app.qt import GlueApplication
+from glue.plugins.dendro_viewer.qt.data_viewer import DendrogramViewer
+
+
+class TestDendrogram:
+
+    def setup_method(self, method):
+        self.data = Data(label='dendrogram', parent=[-1, 0, 1, 1], height=[1.3, 2.2, 3.2, 4.4])
+        self.app = GlueApplication()
+        self.app.session.data_collection.append(self.data)
+        self.viewer = self.app.new_data_viewer(DendrogramViewer)
+        self.viewer.add_data(self.data)
+        for subtool in self.viewer.toolbar.tools['save'].subtools:
+            if subtool.tool_id == 'save:plotlydendro':
+                self.tool = subtool
+                break
+        else:
+            raise Exception("Could not find save:plotlydendro tool in viewer")
+
+    def teardown_method(self, method):
+        self.viewer.close(warn=False)
+        self.viewer = None
+        self.app.close()
+        self.app = None
+
+    def export_figure(self, tmpdir, output_filename):
+        output_path = tmpdir.join(output_filename).strpath
+        with patch('qtpy.compat.getsavefilename') as fd:
+            fd.return_value = output_path, 'html'
+            self.tool.activate()
+        return output_path
+
+    def test_default(self, tmpdir):
+        output_path = self.export_figure(tmpdir, 'test_default.html')
+        assert os.path.exists(output_path)


### PR DESCRIPTION
This PR adds an exporter for the dendrogram viewer. While Plotly has a `create_dendrogram` figure factory, that factory seems to do the dendrogram computation as well. Since the glue viewer assumes that the dendrogram has already been created (i.e. via `astrodendro`), we instead can get something that matches the glue display by using the existing dendrogram data from glue and creating a line-only `Scatter` object. This is a similar approach to what we do with e.g. the histogram viewer, where we use the glue-computed histogram bars rather than Plotly's histogram functionality to match what we see in glue.