### PR TITLE
Bump minimum glue-core to 1.13.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ zip_safe = False
 python_requires = >=3.8
 packages = find:
 install_requires =
-    glue-core>=0.14
+    glue-core>=1.13.1
     plotly
     chart-studio
 


### PR DESCRIPTION
This PR resolves #43. As discussed there, this pin will avoid issues that could arise from mixing `glue-qt` with pre-`glue-qt` versions of `glue-core`.