### PR TITLE
Close dialog in bqplot exporter when saving to a new file

### DIFF
--- a/glue_plotly/html_exporters/bqplot/base.py
+++ b/glue_plotly/html_exporters/bqplot/base.py
@@ -80,6 +80,7 @@ class PlotlyBaseBqplotExport(Tool):
                 display(check_dialog)
         else:
             self.save_figure(filepath)
+            self.viewer.output_widget.clear_output()
 
     def save_figure(self, filepath):
         raise NotImplementedError()


### PR DESCRIPTION
This PR fixes a bug where the file chooser dialog for the bqplot exporters won't close if the selected filename doesn't already exist.