### PR TITLE
Separate glue_qt and glue_jupyter import attempts

### DIFF
--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -5,9 +5,12 @@ from glue.config import settings
 from glue.core import BaseData
 try:
     from glue_qt.viewers.common.data_viewer import DataViewer
-    from glue_jupyter.bqplot.common import BqplotBaseView
 except ImportError:
     DataViewer = type(None)
+
+try:
+    from glue_jupyter.bqplot.common import BqplotBaseView
+except ImportError:
     BqplotBaseView = type(None)
 
 from glue_plotly.utils import is_rgba_hex, opacity_value_string, rgba_hex_to_rgb_hex


### PR DESCRIPTION
This PR fixes a bug where we attempt to import the base `glue_qt` and `glue_jupyter` viewer types in the same `try`/`except`/ block. This means that we only define the types properly if both imports succeed, which is bad. This PR separates these into their own blocks so that they can succeed or fail separately.