### PR TITLE
Test against older glue versions and update bqplot tests

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,67 +32,35 @@ jobs:
           - libhdf5-dev
       envs: |
         # Standard tests
-        - linux: py38-glue113-test
-        - linux: py38-glue114-test
-        - linux: py38-glue115-test
-        - linux: py38-glue116-test
-        - linux: py38-glue117-test
-        - linux: py39-glue113-test
-        - linux: py39-glue114-test
-        - linux: py39-glue115-test
-        - linux: py39-glue116-test
-        - linux: py39-glue117-test
-        - linux: py310-glue113-test
-        - linux: py310-glue114-test
-        - linux: py310-glue115-test
-        - linux: py310-glue116-test
-        - linux: py310-glue117-test
+        - linux: py38-test
+        - linux: py39-test
+        - linux: py310-test
+        - linux: py311-test
         - linux: py311-glue113-test
         - linux: py311-glue114-test
         - linux: py311-glue115-test
         - linux: py311-glue116-test
         - linux: py311-glue117-test
 
-        - macos: py38-glue113-test
-        - macos: py38-glue114-test
-        - macos: py38-glue115-test
-        - macos: py38-glue116-test
-        - macos: py38-glue117-test
-        - macos: py39-glue113-test
-        - macos: py39-glue114-test
-        - macos: py39-glue115-test
-        - macos: py39-glue116-test
-        - macos: py39-glue117-test
-        - macos: py310-glue113-test
-        - macos: py310-glue114-test
-        - macos: py310-glue115-test
-        - macos: py310-glue116-test
-        - macos: py310-glue117-test
+        - macos: py38-test
+        - macos: py39-test
+        - macos: py310-test
+        - macos: py311-test
         - macos: py311-glue113-test
         - macos: py311-glue114-test
         - macos: py311-glue115-test
         - macos: py311-glue116-test
         - macos: py311-glue117-test
 
-        - windows: py38-glue113-test
-        - windows: py38-glue114-test
-        - windows: py38-glue115-test
-        - windows: py38-glue116-test
-        - windows: py38-glue117-test
-        - windows: py39-glue113-test
-        - windows: py39-glue114-test
-        - windows: py39-glue115-test
-        - windows: py39-glue116-test
-        - windows: py39-glue117-test
-        - windows: py310-glue113-test
-        - windows: py310-glue114-test
-        - windows: py310-glue115-test
-        - windows: py310-glue116-test
-        - windows: py310-glue117-test
+        - windows: py38-test
+        - windows: py39-test
+        - windows: py310-test
+        - windows: py311-test
         - windows: py311-glue113-test
         - windows: py311-glue114-test
         - windows: py311-glue115-test
         - windows: py311-glue116-test
+        - windows: py311-glue117-test
 
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,20 +32,67 @@ jobs:
           - libhdf5-dev
       envs: |
         # Standard tests
-        - linux: py38-test
-        - linux: py39-test
-        - linux: py310-test
-        - linux: py311-test
+        - linux: py38-glue113-test
+        - linux: py38-glue114-test
+        - linux: py38-glue115-test
+        - linux: py38-glue116-test
+        - linux: py38-glue117-test
+        - linux: py39-glue113-test
+        - linux: py39-glue114-test
+        - linux: py39-glue115-test
+        - linux: py39-glue116-test
+        - linux: py39-glue117-test
+        - linux: py310-glue113-test
+        - linux: py310-glue114-test
+        - linux: py310-glue115-test
+        - linux: py310-glue116-test
+        - linux: py310-glue117-test
+        - linux: py311-glue113-test
+        - linux: py311-glue114-test
+        - linux: py311-glue115-test
+        - linux: py311-glue116-test
+        - linux: py311-glue117-test
 
-        - macos: py38-test
-        - macos: py39-test
-        - macos: py310-test
-        - macos: py311-test
+        - macos: py38-glue113-test
+        - macos: py38-glue114-test
+        - macos: py38-glue115-test
+        - macos: py38-glue116-test
+        - macos: py38-glue117-test
+        - macos: py39-glue113-test
+        - macos: py39-glue114-test
+        - macos: py39-glue115-test
+        - macos: py39-glue116-test
+        - macos: py39-glue117-test
+        - macos: py310-glue113-test
+        - macos: py310-glue114-test
+        - macos: py310-glue115-test
+        - macos: py310-glue116-test
+        - macos: py310-glue117-test
+        - macos: py311-glue113-test
+        - macos: py311-glue114-test
+        - macos: py311-glue115-test
+        - macos: py311-glue116-test
+        - macos: py311-glue117-test
 
-        - windows: py38-test
-        - windows: py39-test
-        - windows: py310-test
-        - windows: py311-test
+        - windows: py38-glue113-test
+        - windows: py38-glue114-test
+        - windows: py38-glue115-test
+        - windows: py38-glue116-test
+        - windows: py38-glue117-test
+        - windows: py39-glue113-test
+        - windows: py39-glue114-test
+        - windows: py39-glue115-test
+        - windows: py39-glue116-test
+        - windows: py39-glue117-test
+        - windows: py310-glue113-test
+        - windows: py310-glue114-test
+        - windows: py310-glue115-test
+        - windows: py310-glue116-test
+        - windows: py310-glue117-test
+        - windows: py311-glue113-test
+        - windows: py311-glue114-test
+        - windows: py311-glue115-test
+        - windows: py311-glue116-test
 
   publish:
     needs: tests

--- a/glue_plotly/html_exporters/bqplot/tests/test_base.py
+++ b/glue_plotly/html_exporters/bqplot/tests/test_base.py
@@ -7,7 +7,7 @@ class TestBqplotExporter:
     tool_id = None
 
     def setup_method(self, method):
-        self.data = self.test_data()
+        self.data = self.make_data()
         self.app = jglue()
         self.app.session.data_collection.append(self.data)
         self.viewer = self.app.new_data_viewer(self.viewer_type)

--- a/glue_plotly/html_exporters/bqplot/tests/test_histogram.py
+++ b/glue_plotly/html_exporters/bqplot/tests/test_histogram.py
@@ -16,7 +16,7 @@ class TestHistogram(TestBqplotExporter):
     viewer_type = BqplotHistogramView
     tool_id = 'save:bqplot_plotlyhist'
 
-    def test_data(self):
+    def make_data(self):
         return Data(x=[40, 41, 37, 63, 78, 35, 19, 100, 35, 86, 84, 99,
                        87, 56, 2, 71, 22, 36, 10, 1, 26, 70, 45, 20, 8],
                     label='d1')

--- a/glue_plotly/html_exporters/bqplot/tests/test_image.py
+++ b/glue_plotly/html_exporters/bqplot/tests/test_image.py
@@ -18,7 +18,7 @@ class TestImage(TestBqplotExporter):
     viewer_type = BqplotImageView
     tool_id = 'save:bqplot_plotlyimage2d'
 
-    def test_data(self):
+    def make_data(self):
         return Data(label='d1', x=arange(24).reshape((2, 3, 4)), y=ones((2, 3, 4)))
 
     def test_default(self, tmpdir):

--- a/glue_plotly/html_exporters/bqplot/tests/test_profile.py
+++ b/glue_plotly/html_exporters/bqplot/tests/test_profile.py
@@ -16,7 +16,7 @@ class TestProfile(TestBqplotExporter):
     viewer_type = BqplotProfileView
     tool_id = 'save:bqplot_plotlyprofile'
 
-    def test_data(self):
+    def make_data(self):
         return Data(x=[40, 41, 37, 63, 78, 35, 19, 100, 35, 86, 84, 99,
                        87, 56, 2, 71, 22, 36, 10, 1, 26, 70, 45, 20, 8],
                     label='d1')

--- a/glue_plotly/html_exporters/bqplot/tests/test_scatter2d.py
+++ b/glue_plotly/html_exporters/bqplot/tests/test_scatter2d.py
@@ -16,7 +16,7 @@ class TestScatter2D(TestBqplotExporter):
     viewer_type = BqplotScatterView
     tool_id = 'save:bqplot_plotly2d'
 
-    def test_data(self):
+    def make_data(self):
         return Data(x=[1, 2, 3], y=[4, 5, 6], z=[7, 8, 9], label='d1')
 
     def test_default(self, tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-glue{113,114,115,116,117}-test
+envlist = py{38,39,310,311}-test, py311-glue{113,114,115,116,117}-test
 requires = pip >= 18.0
            setuptools >= 30.3.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311}-test
+envlist = py{38,39,310,311}-glue{113,114,115,116,117}-test
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -9,6 +9,12 @@ passenv =
     HOME
 changedir =
     test: .tmp/{envname}
+deps =
+    glue113: glue-core==1.13.*
+    glue114: glue-core==1.14.*
+    glue115: glue-core==1.15.*
+    glue116: glue-core==1.16.*
+    glue117: glue-core==1.17.*
 extras =
     test: test,qt,jupyter
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,14 @@ passenv =
     HOME
 changedir =
     test: .tmp/{envname}
-deps =
-    glue113: glue-core==1.13.*
-    glue114: glue-core==1.14.*
-    glue115: glue-core==1.15.*
-    glue116: glue-core==1.16.*
-    glue117: glue-core==1.17.*
 extras =
     test: test,qt,jupyter
 commands =
+    glue113: pip install glue-core==1.13.* glue-jupyter<=0.19
+    glue114: pip install glue-core==1.14.* glue-jupyter<=0.19
+    glue115: pip install glue-core==1.15.* glue-jupyter<=0.19
+    glue116: pip install glue-core==1.16.* glue-jupyter<=0.19
+    glue117: pip install glue-core==1.17.*
     test: pip freeze
     test: pytest --pyargs glue_plotly --cov glue_plotly {posargs}
 


### PR DESCRIPTION
This PR makes a few updates to the test suite:
* Rename `test_data` to `make_data` in the tests for the bqplot exporters, so that `pytest` doesn't think that it's a test
* Add `glue###` testing environments to test `glue-plotly` against older minor versions of glue. Since our current pin is to `glue-core>=1.13.1`, there's no need to go back further than `1.13.*`. This resolves #54. The solution here isn't the most elegant, but I'm not sure of another way to do this.
* Remove tests for Python < 3.8, since glue requires Python >= 3.8.