### PR TITLE
Add init files for histogram and scatter viewers

### DIFF
--- a/glue_plotly/viewers/histogram/__init__.py
+++ b/glue_plotly/viewers/histogram/__init__.py
@@ -1,0 +1,2 @@
+from .layer_artist import *  # noqa
+from .viewer import *  # noqa

--- a/glue_plotly/viewers/histogram/layer_artist.py
+++ b/glue_plotly/viewers/histogram/layer_artist.py
@@ -7,6 +7,8 @@ from glue_plotly.common.common import fixed_color
 
 from glue_plotly.common.histogram import traces_for_layer
 
+__all__ = ["PlotlyHistogramLayerArtist"]
+
 SCALE_PROPERTIES = {'y_log', 'normalize', 'cumulative'}
 HISTOGRAM_PROPERTIES = SCALE_PROPERTIES | {'layer', 'x_att', 'hist_x_min',
                                            'hist_x_max', 'hist_n_bin', 'x_log'}

--- a/glue_plotly/viewers/histogram/viewer.py
+++ b/glue_plotly/viewers/histogram/viewer.py
@@ -4,10 +4,12 @@ from glue_plotly.common import base_layout_config, base_rectilinear_axis
 from glue_plotly.viewers import PlotlyBaseView
 from glue_plotly.viewers.histogram.layer_artist import PlotlyHistogramLayerArtist
 
-
 from glue_jupyter.registries import viewer_registry
 from glue_jupyter.common.state_widgets.layer_histogram import HistogramLayerStateWidget
 from glue_jupyter.common.state_widgets.viewer_histogram import HistogramViewerStateWidget
+
+
+__all__ = ["PlotlyHistogramView"]
 
 
 @viewer_registry("plotly_histogram")

--- a/glue_plotly/viewers/scatter/__init__.py
+++ b/glue_plotly/viewers/scatter/__init__.py
@@ -1,0 +1,2 @@
+from .layer_artist import *  # noqa
+from .viewer import *  # noqa

--- a/glue_plotly/viewers/scatter/layer_artist.py
+++ b/glue_plotly/viewers/scatter/layer_artist.py
@@ -13,6 +13,9 @@ from glue.viewers.scatter.state import ScatterLayerState
 from plotly.graph_objs import Scatter, Scatterpolar
 
 
+__all__ = ["PlotlyScatterLayerArtist"]
+
+
 CMAP_PROPERTIES = {"cmap_mode", "cmap_att", "cmap_vmin", "cmap_vmax", "cmap"}
 MARKER_PROPERTIES = {
     "size_mode",

--- a/glue_plotly/viewers/scatter/viewer.py
+++ b/glue_plotly/viewers/scatter/viewer.py
@@ -13,6 +13,9 @@ from .layer_artist import PlotlyScatterLayerArtist
 from glue_plotly.viewers import PlotlyBaseView
 
 
+__all__ = ["PlotlyScatterView"]
+
+
 @viewer_registry("plotly_scatter")
 class PlotlyScatterView(PlotlyBaseView):
 


### PR DESCRIPTION
This PR adds `__init__.py` files for the histogram and scatter viewers and adds `__all__` lists in those files.