### PR TITLE
Pin glue-jupyter version in glue 1.17 test environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     glue114: pip install glue-core==1.14.* glue-jupyter<=0.19
     glue115: pip install glue-core==1.15.* glue-jupyter<=0.19
     glue116: pip install glue-core==1.16.* glue-jupyter<=0.19
-    glue117: pip install glue-core==1.17.*
+    glue117: pip install glue-core==1.17.* glue-jupyter<=0.20
     test: pip freeze
     test: pytest --pyargs glue_plotly --cov glue_plotly {posargs}
 


### PR DESCRIPTION
This PR pins the version of `glue-jupyter` that's used in the `glue-117` test environments to fix some test failures due to version incompatibilities.
