### PR TITLE
Update how traces are removed from dotplot layer artist

### DIFF
--- a/glue_plotly/viewers/histogram/dotplot_layer_artist.py
+++ b/glue_plotly/viewers/histogram/dotplot_layer_artist.py
@@ -116,9 +116,13 @@ class PlotlyDotplotLayerArtist(LayerArtist):
     def _update_data(self):
         old_dots = self._get_dots()
         if old_dots:
-            self.view._remove_traces(old_dots)
+            with self.view.figure.batch_update():
+                for trace in old_dots:
+                    self.view._remove_trace_index(trace)
 
         dots = traces_for_layer(self.view, self.state, add_data_label=True)
+        for trace in dots:
+            trace.update(hoverinfo='all', unselected=dict(marker=dict(opacity=self.state.alpha)))
         self._dots_id = dots[0].meta if dots else None
         self.view.figure.add_traces(dots)
 


### PR DESCRIPTION
While using the dotplot layer artist in Solara (for the CosmicDS Hubble data story), I noticed that the way that we're currently removing traces causes an issue in that context when using zoom tools (as the traces need to be redrawn to resize the dots). In particular, something about the event sequencing was causing incorrect (and often out-of-bounds) trace indices to be used for the internal Plotly restyling calls. This PR modifies the trace-removal code to match that in the default histogram layer artist, which resolves this issue.