### PR TITLE
Initialize all trace metadata IDs

### DIFF
--- a/glue_plotly/viewers/histogram/dotplot_layer_artist.py
+++ b/glue_plotly/viewers/histogram/dotplot_layer_artist.py
@@ -2,6 +2,7 @@
 # normalized mode, as a dotplot only makes sense when the heights are integral.
 
 import numpy as np
+from uuid import uuid4
 
 from glue.core.exceptions import IncompatibleAttribute
 from glue.viewers.common.layer_artist import LayerArtist
@@ -35,7 +36,7 @@ class PlotlyDotplotLayerArtist(LayerArtist):
 
         self.view = view
         self.bins = None
-        self._dots_id = None
+        self._dots_id = uuid4().hex
 
         self._viewer_state.add_global_callback(self._update_dotplot)
         self.state.add_global_callback(self._update_dotplot)

--- a/glue_plotly/viewers/histogram/layer_artist.py
+++ b/glue_plotly/viewers/histogram/layer_artist.py
@@ -1,4 +1,5 @@
 import numpy as np
+from uuid import uuid4
 
 from glue.core.exceptions import IncompatibleAttribute
 from glue.viewers.common.layer_artist import LayerArtist
@@ -30,7 +31,7 @@ class PlotlyHistogramLayerArtist(LayerArtist):
 
         self.view = view
         self.bins = None
-        self._bars_id = None
+        self._bars_id = uuid4().hex
 
         self._viewer_state.add_global_callback(self._update_histogram)
         self.state.add_global_callback(self._update_histogram)

--- a/glue_plotly/viewers/scatter/layer_artist.py
+++ b/glue_plotly/viewers/scatter/layer_artist.py
@@ -84,9 +84,13 @@ class PlotlyScatterLayerArtist(LayerArtist):
         scatter = self._create_scatter()
         self.view.figure.add_trace(scatter)
 
-        self._lines_id = None
-        self._error_id = None
-        self._vector_id = None
+        # We want to initialize these to some dummy UUIDs so that
+        # _get_lines, _get_error_bars, _get_vectors, etc. don't pick up
+        # any other traces that tools have added to the viewer, which
+        # will happen if these IDs are None
+        self._lines_id = uuid4().hex
+        self._error_id = uuid4().hex
+        self._vector_id = uuid4().hex
 
     def remove(self):
         self.view._remove_traces([self._get_scatter()])


### PR DESCRIPTION
This PR updates the viewer layer artists to initialize all of the fields used for trace UUIDs when the layer artist is created. Currently these values are left as `None` until the relevant trace type is created. This causes a problem for any tools that create traces on the figure that don't have a `meta` field set: trace-getting methods such as e.g. `_get_lines` in the scatter layer artist can then pick up these traces in their results if `_lines_id` is still `None`. While all of the traces in `glue-plotly` have use the `meta` field of the trace, it's obviously better to make things more robust here rather than demand that any possible tool obey the same pattern.