### PR TITLE
Updates to z-order manipulation

### DIFF
--- a/glue_plotly/viewers/histogram/dotplot_layer_artist.py
+++ b/glue_plotly/viewers/histogram/dotplot_layer_artist.py
@@ -40,6 +40,7 @@ class PlotlyDotplotLayerArtist(LayerArtist):
 
         self._viewer_state.add_global_callback(self._update_dotplot)
         self.state.add_global_callback(self._update_dotplot)
+        self.state.add_callback("zorder", self._update_zorder)
 
     def _get_dots(self):
         return self.view.figure.select_traces(dict(meta=self._dots_id))
@@ -126,11 +127,12 @@ class PlotlyDotplotLayerArtist(LayerArtist):
         self._dots_id = dots[0].meta if dots else None
         self.view.figure.add_traces(dots)
 
-    def _update_zorder(self):
+    def _update_zorder(self, *args):
+        current_traces = self.view.figure.data
         traces = [self.view.selection_layer]
         for layer in self.view.layers:
             traces += list(layer.traces())
-        self.view.figure.data = traces
+        self.view.figure.data = traces + [t for t in current_traces if t not in traces]
 
     def _update_dotplot(self, force=False, **kwargs):
         if (self._viewer_state.hist_x_min is None or
@@ -155,9 +157,6 @@ class PlotlyDotplotLayerArtist(LayerArtist):
 
         if force or len(changed & VISUAL_PROPERTIES) > 0:
             self._update_visual_attributes(changed, force=force)
-
-        if force or "zorder" in changed:
-            self._update_zorder()
 
     def update(self):
         self.state.reset_cache()

--- a/glue_plotly/viewers/histogram/layer_artist.py
+++ b/glue_plotly/viewers/histogram/layer_artist.py
@@ -35,6 +35,7 @@ class PlotlyHistogramLayerArtist(LayerArtist):
 
         self._viewer_state.add_global_callback(self._update_histogram)
         self.state.add_global_callback(self._update_histogram)
+        self.state.add_callback("zorder", self._update_zorder)
 
     def _get_bars(self):
         return self.view.figure.select_traces(dict(meta=self._bars_id))
@@ -122,11 +123,12 @@ class PlotlyHistogramLayerArtist(LayerArtist):
         self._bars_id = bars[0].meta if bars else None
         self.view.figure.add_traces(bars)
 
-    def _update_zorder(self):
+    def _update_zorder(self, *args):
+        current_traces = self.view.figure.data
         traces = [self.view.selection_layer]
         for layer in self.view.layers:
             traces += list(layer.traces())
-        self.view.figure.data = traces
+        self.view.figure.data = traces + [t for t in current_traces if t not in traces]
 
     def _update_histogram(self, force=False, **kwargs):
         if (self._viewer_state.hist_x_min is None or
@@ -151,9 +153,6 @@ class PlotlyHistogramLayerArtist(LayerArtist):
 
         if force or len(changed & VISUAL_PROPERTIES) > 0:
             self._update_visual_attributes(changed, force=force)
-
-        if force or "zorder" in changed:
-            self._update_zorder()
 
     def update(self):
         self.state.reset_cache()

--- a/glue_plotly/viewers/scatter/layer_artist.py
+++ b/glue_plotly/viewers/scatter/layer_artist.py
@@ -69,6 +69,7 @@ class PlotlyScatterLayerArtist(LayerArtist):
 
         self._viewer_state.add_global_callback(self._update_display)
         self.state.add_global_callback(self._update_display)
+        self.state.add_callback("zorder", self._update_zorder)
 
         self.view = view
 
@@ -166,14 +167,12 @@ class PlotlyScatterLayerArtist(LayerArtist):
         if force or len(changed & LINE_PROPERTIES) > 0:
             self._update_lines(changed, force=force)
 
-        if force or "zorder" in changed:
-            self._update_zorder()
-
-    def _update_zorder(self):
+    def _update_zorder(self, *args):
+        current_traces = self.view.figure.data
         traces = [self.view.selection_layer]
         for layer in self.view.layers:
             traces += list(layer.traces())
-        self.view.figure.data = traces
+        self.view.figure.data = traces + [t for t in current_traces if t not in traces]
 
     def _update_lines(self, changed, force=False):
         scatter = self._get_scatter()


### PR DESCRIPTION
This PR fixes up some issues with z-order manipulation that were noticed while using the scatter viewer in CosmicDS. Note that many of the changes here were based on the behavior of the bqplot scatter viewer.

Additionally, the viewers now retain other marks (e.g. those made by tools) when reordering the layers. Since there's no sensible general way to order these sorts of traces, they all just get push to the end of the trace list (higher z-index). If the tool that created these traces needs them in a particular order, it will have to sort that out itself. Note that the ordering of these non-glue traces relative to each other is left untouched.
