### PR TITLE
Bump range of glue versions in test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-test, py311-glue{113,114,115,116,117}-test
+envlist = py{38,39,310,311}-test, py311-glue{116,117,118,119,120}-test
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -12,11 +12,11 @@ changedir =
 extras =
     test: test,qt,jupyter
 commands =
-    glue113: pip install glue-core==1.13.* glue-jupyter<=0.19
-    glue114: pip install glue-core==1.14.* glue-jupyter<=0.19
-    glue115: pip install glue-core==1.15.* glue-jupyter<=0.19
     glue116: pip install glue-core==1.16.* glue-jupyter<=0.19
     glue117: pip install glue-core==1.17.* glue-jupyter<=0.20
+    glue118: pip install glue-core==1.18.* glue-jupyter<=0.20
+    glue119: pip install glue-core==1.19.* glue-jupyter<=0.20
+    glue120: pip install glue-core==1.20.* glue-jupyter<=0.20
     test: pip freeze
     test: pytest --pyargs glue_plotly --cov glue_plotly {posargs}
 


### PR DESCRIPTION
With new releases of glue-core, our test matrix is a bit out of date. This PR moves forward the range of glue versions that we test against.
