### PR TITLE
Fix typo in README link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ glue-plotly can be installed using pip::
 
     pip install glue-plotly
 
-Additionally, glue-plotly is included in the glue `standalone applications <https://glueviz.org/install.html>_`
+Additionally, glue-plotly is included in the glue `standalone applications <https://glueviz.org/install.html>`_
 for MacOS and Windows.
 
 


### PR DESCRIPTION
This PR fixes a small typo in a README link that was causing it to display incorrectly.