### PR TITLE
Update versions of packages in test matrix to account for matplotlib 3.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,11 @@ changedir =
 extras =
     test: test,qt,jupyter
 commands =
-    glue116: pip install glue-core==1.16.* glue-jupyter<=0.19
-    glue117: pip install glue-core==1.17.* glue-jupyter<=0.20
-    glue118: pip install glue-core==1.18.* glue-jupyter<=0.20
-    glue119: pip install glue-core==1.19.* glue-jupyter<=0.20
-    glue120: pip install glue-core==1.20.* glue-jupyter<=0.20
+    glue116: pip install glue-core==1.16.* glue-jupyter<=0.19 matplotlib<3.9
+    glue117: pip install glue-core==1.17.* glue-jupyter<=0.20.1
+    glue118: pip install glue-core==1.18.* glue-jupyter<=0.20.1
+    glue119: pip install glue-core==1.19.* glue-jupyter<=0.20.1
+    glue120: pip install glue-core==1.20.* glue-jupyter<=0.20.1
     test: pip freeze
     test: pytest --pyargs glue_plotly --cov glue_plotly {posargs}
 


### PR DESCRIPTION
This PR resolves #66. The `get_cmap` calls are actually in `glue-jupyter`, so all we need to do here is to do some version handling in our test matrix.