### PR TITLE
Add export to HTML viewer tools

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -69,8 +69,8 @@ def setup_qt():
         }
 
     try:
-        from glue_vispy_viewers.scatter.scatter_viewer import VispyScatterViewer
-        from glue_vispy_viewers.volume.volume_viewer import VispyVolumeViewer
+        from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer
+        from glue_vispy_viewers.volume.qt.volume_viewer import VispyVolumeViewer
     except ImportError:
         pass
     else:

--- a/glue_plotly/html_exporters/bqplot/histogram.py
+++ b/glue_plotly/html_exporters/bqplot/histogram.py
@@ -6,11 +6,11 @@ from glue_plotly.common.histogram import layout_config, traces_for_layer
 from plotly.offline import plot
 import plotly.graph_objs as go
 
-from .base import PlotlyBaseBqplotExport
+from ...jupyter_base_export_tool import JupyterBaseExportTool
 
 
 @viewer_tool
-class PlotlyHistogramBqplotExport(PlotlyBaseBqplotExport):
+class PlotlyHistogramBqplotExport(JupyterBaseExportTool):
     tool_id = 'save:bqplot_plotlyhist'
 
     def save_figure(self, filepath):

--- a/glue_plotly/html_exporters/bqplot/image.py
+++ b/glue_plotly/html_exporters/bqplot/image.py
@@ -7,11 +7,11 @@ from plotly.offline import plot
 import plotly.graph_objs as go
 from plotly.subplots import make_subplots
 
-from .base import PlotlyBaseBqplotExport
+from ...jupyter_base_export_tool import JupyterBaseExportTool
 
 
 @viewer_tool
-class PlotlyImageBqplotExport(PlotlyBaseBqplotExport):
+class PlotlyImageBqplotExport(JupyterBaseExportTool):
     tool_id = 'save:bqplot_plotlyimage2d'
 
     def save_figure(self, filepath):

--- a/glue_plotly/html_exporters/bqplot/profile.py
+++ b/glue_plotly/html_exporters/bqplot/profile.py
@@ -6,11 +6,11 @@ from glue_plotly.common.profile import layout_config, traces_for_layer
 from plotly.offline import plot
 import plotly.graph_objs as go
 
-from .base import PlotlyBaseBqplotExport
+from ...jupyter_base_export_tool import JupyterBaseExportTool
 
 
 @viewer_tool
-class PlotlyProfileBqplotExport(PlotlyBaseBqplotExport):
+class PlotlyProfileBqplotExport(JupyterBaseExportTool):
     tool_id = 'save:bqplot_plotlyprofile'
 
     def save_figure(self, filepath):

--- a/glue_plotly/html_exporters/bqplot/scatter2d.py
+++ b/glue_plotly/html_exporters/bqplot/scatter2d.py
@@ -6,11 +6,11 @@ from glue_plotly.common.scatter2d import rectilinear_layout_config, traces_for_l
 from plotly.offline import plot
 import plotly.graph_objs as go
 
-from .base import PlotlyBaseBqplotExport
+from ...jupyter_base_export_tool import JupyterBaseExportTool
 
 
 @viewer_tool
-class PlotlyScatter2DBqplotExport(PlotlyBaseBqplotExport):
+class PlotlyScatter2DBqplotExport(JupyterBaseExportTool):
     tool_id = 'save:bqplot_plotly2d'
 
     def save_figure(self, filepath):

--- a/glue_plotly/html_exporters/qt/tests/test_scatter3d.py
+++ b/glue_plotly/html_exporters/qt/tests/test_scatter3d.py
@@ -6,7 +6,7 @@ from glue.core import Data
 
 pytest.importorskip('glue_vispy_viewers')
 
-from glue_vispy_viewers.scatter.scatter_viewer import VispyScatterViewer  # noqa: E402
+from glue_vispy_viewers.scatter.qt.scatter_viewer import VispyScatterViewer  # noqa: E402
 
 from .test_base import TestQtExporter  # noqa: E402
 

--- a/glue_plotly/html_exporters/qt/tests/test_volume.py
+++ b/glue_plotly/html_exporters/qt/tests/test_volume.py
@@ -7,7 +7,7 @@ from pytest import importorskip
 importorskip('glue_qt')
 importorskip('glue_vispy_viewers')
 
-from glue_vispy_viewers.volume.volume_viewer import VispyVolumeViewer  # noqa: E402
+from glue_vispy_viewers.volume.qt.volume_viewer import VispyVolumeViewer  # noqa: E402
 
 from numpy import arange, ones  # noqa: E402
 

--- a/glue_plotly/jupyter_base_export_tool.py
+++ b/glue_plotly/jupyter_base_export_tool.py
@@ -7,14 +7,16 @@ import ipyvuetify as v  # noqa
 from ipywidgets import HBox, Layout  # noqa
 from IPython.display import display  # noqa
 from ipyfilechooser import FileChooser  # noqa
+from glue_plotly import PLOTLY_LOGO
 
-from glue_plotly import PLOTLY_LOGO  # noqa
+__all__ = ["JupyterBaseExportTool"]
 
 
-class PlotlyBaseBqplotExport(Tool):
+class JupyterBaseExportTool(Tool):
+
     icon = PLOTLY_LOGO
-    action_text = 'Save Plotly HTML page'
-    tool_tip = 'Save Plotly HTML page'
+    action_text = "Save Plotly HTML page"
+    tool_tip = "Save Plotly HTML page"
 
     def activate(self):
         file_chooser = FileChooser(getcwd())

--- a/glue_plotly/utils.py
+++ b/glue_plotly/utils.py
@@ -1,6 +1,14 @@
 from re import match, sub
 
-__all__ = ['cleaned_labels', 'mpl_ticks_values']
+__all__ = [
+    'cleaned_labels',
+    'mpl_ticks_values',
+    'opacity_value_string',
+    'rgba_string_to_values',
+    'is_rgba_hex',
+    'is_rgb_hex',
+    'rgba_hex_to_rgb_hex',
+]
 
 
 def cleaned_labels(labels):

--- a/glue_plotly/viewers/histogram/viewer.py
+++ b/glue_plotly/viewers/histogram/viewer.py
@@ -15,7 +15,9 @@ __all__ = ["PlotlyHistogramView"]
 @viewer_registry("plotly_histogram")
 class PlotlyHistogramView(PlotlyBaseView):
 
-    tools = ['plotly:home', 'plotly:zoom', 'plotly:pan', 'plotly:xrange', 'plotly:hover']
+    tools = ['plotly:save', 'plotly:home',
+             'plotly:zoom', 'plotly:pan',
+             'plotly:xrange', 'plotly:hover']
 
     allow_duplicate_data = False
     allow_duplicate_subset = False

--- a/glue_plotly/viewers/scatter/viewer.py
+++ b/glue_plotly/viewers/scatter/viewer.py
@@ -19,8 +19,11 @@ __all__ = ["PlotlyScatterView"]
 @viewer_registry("plotly_scatter")
 class PlotlyScatterView(PlotlyBaseView):
 
-    tools = ['plotly:home', 'plotly:zoom', 'plotly:pan', 'plotly:xrange',
-             'plotly:yrange', 'plotly:rectangle', 'plotly:lasso', 'plotly:hover']
+    tools = ['plotly:save', 'plotly:home',
+             'plotly:zoom', 'plotly:pan',
+             'plotly:xrange', 'plotly:yrange',
+             'plotly:rectangle', 'plotly:lasso',
+             'plotly:hover']
 
     allow_duplicate_data = False
     allow_duplicate_subset = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,12 @@ test =
     pytest
     pytest-cov
     mock
-    glue-vispy-viewers
 qt =
     glue-qt
     PySide2;python_version=="2"
     PyQt5;python_version>="3"
+3d =
+    glue-vispy-viewers>=1.2.1
 jupyter =
     glue-jupyter
     ipyvuetify

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv =
 changedir =
     test: .tmp/{envname}
 extras =
-    test: test,qt,jupyter
+    test: test,qt,3d,jupyter
 commands =
     glue116: pip install glue-core==1.16.* glue-jupyter<=0.19 matplotlib<3.9
     glue117: pip install glue-core==1.17.* glue-jupyter<=0.20.1


### PR DESCRIPTION
This PR adds tools to the viewers to allow exporting the current figure to an interactive HTML file. This is essentially the equivalent of the Plotly export tools for the matplotlib and bqplot viewers, but since the viewers here are already using Plotly, we can just directly use the viewer figure's ability to export to HTML. Since we restrict a lot of the default Plotly functionality (zooming, selection, panning, etc.) and then expose them via tools in the viewer, we make sure to re-enable these in the exported HTML.

For selecting an export filepath, these tools use the same `ipyfilechooser` setup that the bqplot exporters already use. Thus, I've refactored this out into a base Jupyter export tool so that both the exporters and this saving tool can share that functionality.