### PR TITLE
Fix CI issues

### DIFF
--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -181,7 +181,7 @@ def colorscale_info(layer_state, interval, contrast_bias):
     unmapped_space = np.linspace(0, 1, 60)
     mapped_space = np.linspace(mapped_bounds[0], mapped_bounds[1], 60)
     color_space = [cmap(b)[:3] for b in mapped_space]
-    color_values = [tuple(256 * v for v in p) for p in color_space]
+    color_values = [tuple(float(256 * v) for v in p) for p in color_space]
     colorscale = [[0, 'rgb{0}'.format(color_values[0])]] + \
                  [[u, 'rgb{0}'.format(c)] for u, c in zip(unmapped_space, color_values)] + \
                  [[1, 'rgb{0}'.format(color_values[-1])]]

--- a/glue_plotly/common/tests/test_dendrogram.py
+++ b/glue_plotly/common/tests/test_dendrogram.py
@@ -4,6 +4,7 @@ import pytest
 
 from glue.config import settings
 from glue.core import Data
+from glue.tests.helpers import make_skipper
 from glue_qt.app import GlueApplication
 from glue_qt.plugins.dendro_viewer import DendrogramViewer
 
@@ -12,6 +13,11 @@ from glue_plotly.common.common import base_rectilinear_axis
 from glue_plotly.common.dendrogram import trace_for_layer, x_axis
 
 
+NUMPY_LT_2, requires_numpy_lt2 = make_skipper('numpy', version='2.0', skip_if='ge')
+
+
+# Workaround until for the issue solved in https://github.com/glue-viz/glue-qt/pull/19
+@requires_numpy_lt2
 class TestDendrogram:
 
     def setup_method(self, method):

--- a/glue_plotly/html_exporters/qt/tests/test_dendrogram.py
+++ b/glue_plotly/html_exporters/qt/tests/test_dendrogram.py
@@ -1,6 +1,7 @@
 import os
 
 from glue.core import Data
+from glue.tests.helpers import make_skipper
 
 from pytest import importorskip
 
@@ -11,6 +12,11 @@ from glue_qt.plugins.dendro_viewer.data_viewer import DendrogramViewer  # noqa: 
 from .test_base import TestQtExporter  # noqa: E402
 
 
+NUMPY_LT_2, requires_numpy_lt2 = make_skipper('numpy', version='2.0', skip_if='ge')
+
+
+# Workaround until for the issue solved in https://github.com/glue-viz/glue-qt/pull/19
+@requires_numpy_lt2
 class TestDendrogram(TestQtExporter):
 
     viewer_type = DendrogramViewer


### PR DESCRIPTION
This PR resolves #74, as well as fix another test issue with creating image exports:
* As mentioned in #74, the CI issue there is related to the bug fixed by https://github.com/glue-viz/glue-qt/pull/19. This PR works around this by skipping the dendrogram tests if `numpy>=2.0`
* This PR also fixes an issue that popped up with the Plotly's colormap validator. This is also related to numpy as it involved using numpy float64s inside of format strings.