### PR TITLE
Add unique class to each viewer instance

### DIFF
--- a/glue_plotly/viewers/common/tests/__init__.py
+++ b/glue_plotly/viewers/common/tests/__init__.py
@@ -1,0 +1,1 @@
+from .base_viewer_tests import BasePlotlyViewTests  # noqa

--- a/glue_plotly/viewers/common/tests/base_viewer_tests.py
+++ b/glue_plotly/viewers/common/tests/base_viewer_tests.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+
+class BasePlotlyViewTests:
+
+    def setup_method(self, method):
+        pass
+
+    def teardown_method(self, method):
+        pass
+
+    def test_unique_class(self):
+        unique_class = self.viewer.unique_class
+        prefix = "glue-plotly-"
+        prefix_len = len(prefix)
+        assert unique_class.startswith(prefix)
+        assert len(unique_class) == prefix_len + 32
+
+        # Test UUID validity by seeing if we can construct a UUID instance
+        assert UUID(unique_class[prefix_len:])
+
+        assert unique_class in self.viewer.figure._dom_classes

--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -37,6 +37,9 @@ class PlotlyBaseView(IPyWidgetView):
         layout = self._create_layout_config()
         self.figure = go.FigureWidget(layout=layout)
 
+        self._unique_class = f"glue-plotly-{uuid4().hex}"
+        self.figure.add_class(self._unique_class)
+
         self.selection_layer_id = uuid4().hex
         selection_layer = go.Heatmap(x0=0.5,
                                      dx=1,
@@ -156,3 +159,8 @@ class PlotlyBaseView(IPyWidgetView):
     # TODO: Should we have anything here?
     def redraw(self):
         pass
+
+    @property
+    def unique_class(self):
+        """This is a unique identifier, based on a v4 UUID, that is assigned to the root widget as a class."""
+        return self._unique_class

--- a/glue_plotly/viewers/histogram/tests/test_viewer.py
+++ b/glue_plotly/viewers/histogram/tests/test_viewer.py
@@ -3,10 +3,11 @@ from glue_jupyter import JupyterApplication
 from plotly.graph_objects import Bar
 
 from glue_plotly.common import DEFAULT_FONT
+from glue_plotly.viewers.common.tests import BasePlotlyViewTests
 from glue_plotly.viewers.histogram import PlotlyHistogramView
 
 
-class TestHistogramViewer:
+class TestHistogramViewer(BasePlotlyViewTests):
 
     def setup_method(self, method):
         self.data = Data(label="histogram", x=[1, 1, 1, 2, 2, 3, 3, 3, 4, 6, 6])

--- a/glue_plotly/viewers/scatter/tests/test_viewer.py
+++ b/glue_plotly/viewers/scatter/tests/test_viewer.py
@@ -5,12 +5,14 @@ from glue_jupyter import JupyterApplication
 from plotly.graph_objects import Scatter
 
 from glue_plotly.common import DEFAULT_FONT
+from glue_plotly.viewers.common.tests import BasePlotlyViewTests
 from glue_plotly.viewers.scatter import PlotlyScatterView
 
 
-class TestScatterView:
+class TestScatterView(BasePlotlyViewTests):
 
     def setup_method(self, method):
+        super().setup_method(method)
         self.data = Data(label="histogram", x=[1, 3, 5, 7, 9], y=[2, 4, 6, 8, 10])
         self.app = JupyterApplication()
         self.app.session.data_collection.append(self.data)
@@ -33,6 +35,7 @@ class TestScatterView:
     def teardown_method(self, method):
         self.viewer = None
         self.app = None
+        super().teardown_method(method)
 
     def test_basic(self):
         assert len(self.viewer.layers) == 1


### PR DESCRIPTION
This PR adds a unique identified to each viewer that will be added as a class for the root element of the `FigureWidget` in the DOM. This allows a client that can also run JS in the browser (e.g. a Vue component being used in a Solara app) an easy way to directly reference any figure(s) for a given viewer from a JS context in the browser. Note that this is a class, not an id - each view of the `FigureWidget` will have the same class. This class is accessible Python-side as `viewer.unique_class`.

The class is constructed from a v4 UUID in order to be unique. The format of the class is `glue-plotly-<UUID>`. This format has two purposes:
* Make sure that the class starts with a letter
* Clearly tell where this class is being applied from
