### PR TITLE
Remove viewer modebar via config

### DIFF
--- a/glue_plotly/viewers/common/tests/base_viewer_tests.py
+++ b/glue_plotly/viewers/common/tests/base_viewer_tests.py
@@ -20,3 +20,7 @@ class BasePlotlyViewTests:
         assert UUID(unique_class[prefix_len:])
 
         assert unique_class in self.viewer.figure._dom_classes
+
+    def test_config(self):
+        config = self.viewer.figure._config
+        assert config["displayModeBar"] is False

--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -33,7 +33,7 @@ class PlotlyBaseView(IPyWidgetView):
 
         layout = self._create_layout_config()
         self.figure = go.FigureWidget(layout=layout)
-        self.figure._config = self.figure._config | {"displayModeBar": False}
+        self.figure._config = self.figure._config = {**self.figure._config, "displayModeBar": False}
 
         self._unique_class = f"glue-plotly-{uuid4().hex}"
         self.figure.add_class(self._unique_class)

--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -21,9 +21,6 @@ class PlotlyBaseView(IPyWidgetView):
         hovermode=False, hoverdistance=1,
         dragmode=False, showlegend=False, grid=None,
         newselection=dict(line=dict(dash="dash"), mode='immediate'),
-        modebar=dict(remove=['toimage', 'zoom', 'pan', 'lasso', 'zoomIn2d',
-                             'zoomOut2d', 'select', 'autoscale', 'resetScale2d',
-                             'resetViews'])
     )
 
     allow_duplicate_data = False
@@ -36,6 +33,7 @@ class PlotlyBaseView(IPyWidgetView):
 
         layout = self._create_layout_config()
         self.figure = go.FigureWidget(layout=layout)
+        self.figure._config = self.figure._config | {"displayModeBar": False}
 
         self._unique_class = f"glue-plotly-{uuid4().hex}"
         self.figure.add_class(self._unique_class)


### PR DESCRIPTION
This PR modifies the viewer to remove the figure's modebar via the configuration. This lets us hide the modebar with a single setting, rather than needing to enumerate every button that we want to hide in the layout. This also will remove the modebar's vertical space as well as the Plotly logo that current shows on a hover.