### PR TITLE
Add default viewer dimensions for Plotly-based viewers

### DIFF
--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -25,7 +25,7 @@ def dimensions(viewer):
     elif isinstance(viewer, BqplotBaseView):
         return 1200, 600  # TODO: What to do here?
     else:  # For now, this means a Plotly-based viewer
-        return viewer.figure.layout.width, viewer.figure.layout.height
+        return viewer.figure.layout.width or 600, viewer.figure.layout.height or 400
 
 
 def layers_to_export(viewer):


### PR DESCRIPTION
This PR adds default viewer dimensions of width = 600, height = 400 for Plotly-based viewers in the `dimensions` utility function.