### PR TITLE
Add dendrogram viewer to Chart Studio exporter

### DIFF
--- a/glue_plotly/web/export_plotly.py
+++ b/glue_plotly/web/export_plotly.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from glue.core.layout import Rectangle, snap_to_grid
 
-from glue_plotly.common import histogram, profile, scatter2d, \
+from glue_plotly.common import dendrogram, histogram, profile, scatter2d, \
     data_count, layers_to_export, base_rectilinear_axis
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
@@ -139,6 +139,20 @@ def export_profile(viewer):
     yaxis = profile.axis_from_mpl(viewer, 'y', glue_ticks=False)
 
     return traces, xaxis, yaxis
+
+
+def export_dendrogram(viewer):
+    traces = []
+    layers = layers_to_export(viewer)
+    add_data_label = data_count(layers) > 1
+    for layer in layers:
+        data = layer.mpl_artists[0].get_xydata()
+        trace = dendrogram.trace_for_layer(layer.state, data, add_data_label=add_data_label)
+        traces.append(trace)
+
+    config = dendrogram.layout_config_from_mpl(viewer)
+
+    return traces, config["xaxis"], config["yaxis"]
 
 
 def build_plotly_call(app):

--- a/glue_plotly/web/qt/__init__.py
+++ b/glue_plotly/web/qt/__init__.py
@@ -1,3 +1,6 @@
+from glue_plotly.web.export_plotly import export_dendrogram
+
+
 def setup():
 
     from glue.config import exporters
@@ -6,6 +9,11 @@ def setup():
                                                export_profile)
     from glue_plotly.web.qt.exporter import save_plotly
 
+    try:
+        from glue_qt.plugins.dendro_viewer import DendrogramViewer
+        DISPATCH[DendrogramViewer] = export_dendrogram
+    except ImportError:
+        pass
     from glue_qt.viewers.scatter import ScatterViewer
     from glue_qt.viewers.histogram import HistogramViewer
     from glue_qt.viewers.profile import ProfileViewer

--- a/glue_plotly/web/qt/tests/test_exporter.py
+++ b/glue_plotly/web/qt/tests/test_exporter.py
@@ -11,6 +11,12 @@ from plotly.exceptions import PlotlyError
 from glue.core import Data, DataCollection
 from glue_qt.app import GlueApplication
 from glue_qt.viewers.histogram import HistogramViewer
+from glue_qt.viewers.profile import ProfileViewer
+from glue_qt.viewers.scatter import ScatterViewer
+try:
+    from glue_qt.plugins.dendro_viewer import DendrogramViewer
+except ImportError:
+    DendrogramViewer = None
 
 from glue_plotly.web.export_plotly import build_plotly_call
 
@@ -59,11 +65,25 @@ class TestQtPlotlyExporter:
         self.app = GlueApplication(dc)
 
         data.style.color = '#000000'
-        v = self.app.new_data_viewer(HistogramViewer, data=data)
-        v.component = data.id['y']
-        v.xmin = 0
-        v.xmax = 10
-        v.bins = 20
+        hv = self.app.new_data_viewer(HistogramViewer, data=data)
+        hv.component = data.id['y']
+        hv.xmin = 0
+        hv.xmax = 10
+        hv.bins = 20
+
+        sv = self.app.new_data_viewer(ScatterViewer, data=data)
+        sv.state.x_att = data.id['x']
+        sv.state.y_att = data.id['y']
+
+        pv = self.app.new_data_viewer(ProfileViewer, data=data)
+        pv.state.x_att = data.id['Pixel Axis 0 [x]']
+
+        if DendrogramViewer is not None:
+            dendro_data = Data(label='dendrogram', parent=[-1, 0, 1, 1], height=[1.3, 2.2, 3.2, 4.4])
+            dc.append(dendro_data)
+            dv = self.app.new_data_viewer(DendrogramViewer, data=dendro_data)
+            dv.state.height_att = dendro_data.id['height']
+            dv.state.parent_att = dendro_data.id['parent']
 
         self.args, self.kwargs = build_plotly_call(self.app)
 

--- a/glue_plotly/web/qt/tests/test_exporter.py
+++ b/glue_plotly/web/qt/tests/test_exporter.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import json
+from importlib.metadata import version
+from packaging.version import Version
 
 import mock
 import pytest
 from mock import patch
+from numpy import __version__ as numpy_version
 from chart_studio.plotly import plotly
 from plotly.exceptions import PlotlyError
 
@@ -25,6 +28,11 @@ from ....web.qt import setup
 
 plotly_sign_in = mock.MagicMock()
 plotly_plot = mock.MagicMock()
+
+
+# glue-qt doesn't have a __version__ so we need to do this
+GLUE_QT_GE_031 = Version(version("glue_qt")) > Version('0.3.1')
+NUMPY_LT_2 = Version(numpy_version) < Version('2')
 
 
 SIGN_IN_ERROR = """
@@ -78,7 +86,8 @@ class TestQtPlotlyExporter:
         pv = self.app.new_data_viewer(ProfileViewer, data=data)
         pv.state.x_att = data.id['Pixel Axis 0 [x]']
 
-        if DendrogramViewer is not None:
+        # Workaround until for the issue solved in https://github.com/glue-viz/glue-qt/pull/19
+        if (NUMPY_LT_2 or GLUE_QT_GE_031) and DendrogramViewer is not None:
             dendro_data = Data(label='dendrogram', parent=[-1, 0, 1, 1], height=[1.3, 2.2, 3.2, 4.4])
             dc.append(dendro_data)
             dv = self.app.new_data_viewer(DendrogramViewer, data=dendro_data)


### PR DESCRIPTION
This PR adds support for the dendrogram viewer to the Chart Studio exporter. The setup here is similar to the other supported viewers and is very straightforward.