### PR TITLE
Log axes for viewers

### DIFF
--- a/glue_plotly/viewers/common/tests/base_viewer_tests.py
+++ b/glue_plotly/viewers/common/tests/base_viewer_tests.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 
+from numpy import log10, float64
+
 
 class BasePlotlyViewTests:
 
@@ -24,3 +26,36 @@ class BasePlotlyViewTests:
     def test_config(self):
         config = self.viewer.figure._config
         assert config["displayModeBar"] is False
+
+    def test_log_x_axis(self):
+        assert self.viewer.axis_x.type == "linear"
+        self.viewer.state.x_log = True
+        assert self.viewer.axis_x.type == "log"
+        self.viewer.state.x_log = False
+        assert self.viewer.axis_x.type == "linear"
+
+    def test_log_y_axis(self):
+        assert self.viewer.axis_y.type == "linear"
+        self.viewer.state.y_log = True
+        assert self.viewer.axis_y.type == "log"
+        self.viewer.state.y_log = False
+        assert self.viewer.axis_y.type == "linear"
+
+    def test_set_x_axis_bounds(self):
+        self.viewer.state.x_min = 1
+        self.viewer.state.x_max = 25
+        print(self.viewer.axis_x['range'])
+        assert self.viewer.axis_x['range'] == (1, 25)
+        self.viewer.state.x_log = True
+        self.viewer.state.x_min = 10
+        self.viewer.state.x_max = 1000
+        assert self.viewer.axis_x['range'] == (1.0, 3.0)
+
+    def test_set_y_axis_bounds(self):
+        self.viewer.state.y_min = 1
+        self.viewer.state.y_max = 25
+        assert self.viewer.axis_y['range'] == (1, 25)
+        self.viewer.state.y_log = True
+        self.viewer.state.y_min = 10
+        self.viewer.state.y_max = 1000
+        assert self.viewer.axis_y['range'] == (1.0, 3.0)

--- a/glue_plotly/viewers/common/tests/base_viewer_tests.py
+++ b/glue_plotly/viewers/common/tests/base_viewer_tests.py
@@ -1,7 +1,5 @@
 from uuid import UUID
 
-from numpy import log10, float64
-
 
 class BasePlotlyViewTests:
 
@@ -44,7 +42,6 @@ class BasePlotlyViewTests:
     def test_set_x_axis_bounds(self):
         self.viewer.state.x_min = 1
         self.viewer.state.x_max = 25
-        print(self.viewer.axis_x['range'])
         assert self.viewer.axis_x['range'] == (1, 25)
         self.viewer.state.x_log = True
         self.viewer.state.x_min = 10

--- a/glue_plotly/viewers/common/tests/utils.py
+++ b/glue_plotly/viewers/common/tests/utils.py
@@ -12,6 +12,8 @@ class ExampleState(ViewerState):
     x_max = CallbackProperty(1)
     y_min = CallbackProperty(0)
     y_max = CallbackProperty(1)
+    x_log = CallbackProperty(False)
+    y_log = CallbackProperty(False)
     show_axes = CallbackProperty(True)
 
     def reset_limits(self):

--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -127,16 +127,16 @@ class PlotlyBaseView(IPyWidgetView):
     def set_selection_callback(self, on_selection):
         self.selection_layer.on_selection(on_selection)
 
-    def _x_axis_range_from_state(self): 
+    def _x_axis_range_from_state(self):
         x_range = [self.state.x_min, self.state.x_max]
         if self.state.x_log:
-            x_range = list(log10([float(x) for x in x_range]))
+            x_range = tuple(log10([float(x) for x in x_range]))
         return x_range
 
-    def _y_axis_range_from_state(self): 
+    def _y_axis_range_from_state(self):
         y_range = [self.state.y_min, self.state.y_max]
         if self.state.y_log:
-            y_range = list(log10([float(y) for y in y_range]))
+            y_range = tuple(log10([float(y) for y in y_range]))
         return y_range
 
     @avoid_circular
@@ -160,7 +160,7 @@ class PlotlyBaseView(IPyWidgetView):
     def _set_x_state_bounds(self, x_range):
         with delay_callback(self.state, 'x_min', 'x_max'):
             if self.state.x_log:
-                x_range = [pow(10, x) for x in x_range]
+                x_range = tuple(pow(10, x) for x in x_range)
             self.state.x_min = x_range[0]
             self.state.x_max = x_range[1]
 
@@ -168,7 +168,7 @@ class PlotlyBaseView(IPyWidgetView):
     def _set_y_state_bounds(self, y_range):
         with delay_callback(self.state, 'y_min', 'y_max'):
             if self.state.y_log:
-                y_range = [pow(10, y) for y in y_range]
+                y_range = tuple(pow(10, y) for y in y_range)
             self.state.y_min = y_range[0]
             self.state.y_max = y_range[1]
 

--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -52,8 +52,10 @@ class PlotlyBaseView(IPyWidgetView):
         self.state.add_callback('y_axislabel', self.update_y_axislabel)
         self.state.add_callback('x_min', self._update_plotly_x_limits)
         self.state.add_callback('x_max', self._update_plotly_x_limits)
+        self.state.add_callback('x_log', self._update_x_log)
         self.state.add_callback('y_min', self._update_plotly_y_limits)
         self.state.add_callback('y_max', self._update_plotly_y_limits)
+        self.state.add_callback('y_log', self._update_y_log)
         self.state.add_callback('show_axes', self._update_axes_visible)
 
         self.axis_x.on_change(lambda _obj, x_range: self._set_x_state_bounds(x_range), 'range')
@@ -99,6 +101,14 @@ class PlotlyBaseView(IPyWidgetView):
 
     def update_y_axislabel(self, label):
         self.axis_y['title'].update(text=label)
+
+    def _update_x_log(self, log):
+        axis_type = 'log' if log else 'linear'
+        self.axis_x.update(type=axis_type)
+
+    def _update_y_log(self, log):
+        axis_type = 'log' if log else 'linear'
+        self.axis_y.update(type=axis_type)
 
     def _update_selection_layer_bounds(self):
         x0 = 0.5 * (self.state.x_min + self.state.x_max)

--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -50,6 +50,8 @@ class PlotlyBaseView(IPyWidgetView):
                                      visible=False)
         self.figure.add_trace(selection_layer)
 
+        # Note that we need the log updates to be high priority for the histogram viewer
+        # so that the axes are updated before the limits are reset
         self.state.add_callback('x_axislabel', self.update_x_axislabel)
         self.state.add_callback('y_axislabel', self.update_y_axislabel)
         self.state.add_callback('x_min', self._update_plotly_x_limits)

--- a/glue_plotly/viewers/histogram/viewer.py
+++ b/glue_plotly/viewers/histogram/viewer.py
@@ -5,7 +5,6 @@ from glue_plotly.viewers.histogram.layer_artist import PlotlyHistogramLayerArtis
 
 from glue_jupyter.registries import viewer_registry
 from glue_jupyter.common.state_widgets.layer_histogram import HistogramLayerStateWidget
-from glue_jupyter.common.state_widgets.viewer_histogram import HistogramViewerStateWidget
 from glue_plotly.viewers.histogram.state import PlotlyHistogramViewerState
 from glue_plotly.viewers.histogram.viewer_state_widget import PlotlyHistogramViewerStateWidget
 

--- a/glue_plotly/viewers/histogram/viewer.py
+++ b/glue_plotly/viewers/histogram/viewer.py
@@ -7,6 +7,7 @@ from glue_jupyter.registries import viewer_registry
 from glue_jupyter.common.state_widgets.layer_histogram import HistogramLayerStateWidget
 from glue_jupyter.common.state_widgets.viewer_histogram import HistogramViewerStateWidget
 from glue_plotly.viewers.histogram.state import PlotlyHistogramViewerState
+from glue_plotly.viewers.histogram.viewer_state_widget import PlotlyHistogramViewerStateWidget
 
 
 __all__ = ["PlotlyHistogramView"]
@@ -23,7 +24,7 @@ class PlotlyHistogramView(PlotlyBaseView):
     allow_duplicate_subset = False
 
     _state_cls = PlotlyHistogramViewerState
-    _options_cls = HistogramViewerStateWidget
+    _options_cls = PlotlyHistogramViewerStateWidget
     _data_artist_cls = PlotlyHistogramLayerArtist
     _subset_artist_cls = PlotlyHistogramLayerArtist
     _layer_style_widget_cls = HistogramLayerStateWidget

--- a/glue_plotly/viewers/histogram/viewer_state_widget.py
+++ b/glue_plotly/viewers/histogram/viewer_state_widget.py
@@ -1,0 +1,6 @@
+from glue_jupyter.common.state_widgets.viewer_histogram import HistogramViewerStateWidget
+
+
+class PlotlyHistogramViewerStateWidget(HistogramViewerStateWidget):
+
+    template_file = (__file__, "viewer_state_widget.vue")

--- a/glue_plotly/viewers/histogram/viewer_state_widget.vue
+++ b/glue_plotly/viewers/histogram/viewer_state_widget.vue
@@ -1,0 +1,53 @@
+<template>
+    <div>
+        <div>
+            <v-select :items="x_att_items" label="x axis" v-model="x_att_selected"/>
+        </div>
+        <div>
+            <v-btn-toggle dense multiple :value="modeSet" @change="modeSetChange">
+
+                <v-tooltip bottom>
+                    <template v-slot:activator="{ on }">
+                        <v-btn v-on="on" small value="normalize">
+                            <v-icon>unfold_more</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>normalize</span>
+                </v-tooltip>
+
+                <v-tooltip bottom>
+                    <template v-slot:activator="{ on }">
+                        <v-btn v-on="on" small value="cumulative">
+                            <v-icon>trending_up</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>cumulative</span>
+                </v-tooltip>
+            </v-btn-toggle>
+        </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">x log</v-subheader>
+            <v-switch v-model="glue_state.x_log" hide-details style="margin-top: 0"/>
+        </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">y log</v-subheader>
+            <v-switch v-model="glue_state.y_log" hide-details style="margin-top: 0"/>
+        </div>
+        <v-switch v-model="glue_state.show_axes" label="Show axes" hide-details/>
+    </div>
+</template>
+<script>
+    module.exports = {
+        computed: {
+            modeSet() {
+                return [this.glue_state.normalize && 'normalize', this.glue_state.cumulative && 'cumulative']
+            }
+        },
+        methods: {
+            modeSetChange(v) {
+                this.glue_state.normalize = v.includes('normalize');
+                this.glue_state.cumulative = v.includes('cumulative');
+            }
+        }
+    }
+</script>

--- a/glue_plotly/viewers/scatter/viewer.py
+++ b/glue_plotly/viewers/scatter/viewer.py
@@ -5,11 +5,11 @@ from glue.viewers.scatter.state import ScatterViewerState
 
 from glue_plotly.common.scatter2d import polar_layout_config, radial_axis, rectilinear_layout_config
 
-from glue_jupyter.common.state_widgets.viewer_scatter import ScatterViewerStateWidget
 from glue_jupyter.common.state_widgets.layer_scatter import ScatterLayerStateWidget
 from glue_jupyter.registries import viewer_registry
 
 from .layer_artist import PlotlyScatterLayerArtist
+from .viewer_state_widget import PlotlyScatterViewerStateWidget
 from glue_plotly.viewers import PlotlyBaseView
 
 
@@ -30,7 +30,7 @@ class PlotlyScatterView(PlotlyBaseView):
     large_data_size = 1e7
 
     _state_cls = ScatterViewerState
-    _options_cls = ScatterViewerStateWidget
+    _options_cls = PlotlyScatterViewerStateWidget
     _data_artist_cls = PlotlyScatterLayerArtist
     _subset_artist_cls = PlotlyScatterLayerArtist
     _layer_style_widget_cls = ScatterLayerStateWidget

--- a/glue_plotly/viewers/scatter/viewer_state_widget.py
+++ b/glue_plotly/viewers/scatter/viewer_state_widget.py
@@ -1,0 +1,6 @@
+from glue_jupyter.common.state_widgets.viewer_scatter import ScatterViewerStateWidget
+
+
+class PlotlyScatterViewerStateWidget(ScatterViewerStateWidget):
+
+    template_file = (__file__, "viewer_state_widget.vue")

--- a/glue_plotly/viewers/scatter/viewer_state_widget.vue
+++ b/glue_plotly/viewers/scatter/viewer_state_widget.vue
@@ -1,0 +1,30 @@
+<template>
+    <div class="glue-viewer-scatter-plotly">
+        <div>
+            <v-select label="x axis" :items="x_att_items" v-model="x_att_selected" hide-details />
+        </div>
+        <div>
+            <v-select label="y axis" :items="y_att_items" v-model="y_att_selected" hide-details />
+        </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">x log</v-subheader>
+            <v-switch v-model="glue_state.x_log" hide-details style="margin-top: 0"/>
+        </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">y log</v-subheader>
+            <v-switch v-model="glue_state.y_log" hide-details style="margin-top: 0"/>
+        </div>
+        <div>
+            <v-subheader class="pl-0 slider-label">show axes</v-subheader>
+            <v-switch v-model="glue_state.show_axes" hide-details style="margin-top: 0"/>
+        </div>
+    </div>
+</template>
+
+<style id="viewer_image">
+    .glue-viewer-scatter-plotly .v-subheader.slider-label {
+        font-size: 12px;
+        height: 16px;
+        margin-top: 6px;
+    }
+</style>

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ jupyter =
     ipyfilechooser
 
 [options.package_data]
-* = *.png, *.svg, *.ui
+* = *.png, *.svg, *.ui, *.vue
 
 [options.entry_points]
 glue.plugins =


### PR DESCRIPTION
This PR enables using log axes for the viewers. The implementation here is mostly straightforward using the `type="log"` option of Plotly's x and y axes. The only sublety is that we need the log updates to be high priority so that the axis updates happen before the limit resets in the histogram viewer. Additionally, this updates the scatter and histogram viewer state widgets to add switches for toggling the x/y log axes. These widgets are based on the glue-jupyter widgets, but we need our own versions here as this option isn't implemented for the bqplot viewers.