### PR TITLE
Use devdeps in CI workflow

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -36,6 +36,7 @@ jobs:
         - linux: py39-test
         - linux: py310-test
         - linux: py311-test
+        - linux: py311-test-devdeps
         - linux: py311-glue116-test
         - linux: py311-glue117-test
         - linux: py311-glue118-test
@@ -46,6 +47,7 @@ jobs:
         - macos: py39-test
         - macos: py310-test
         - macos: py311-test
+        - macos: py311-test-devdeps
         - macos: py311-glue116-test
         - macos: py311-glue117-test
         - macos: py311-glue118-test
@@ -56,6 +58,7 @@ jobs:
         - windows: py39-test
         - windows: py310-test
         - windows: py311-test
+        - windows: py311-test-devdeps
         - windows: py311-glue116-test
         - windows: py311-glue117-test
         - windows: py311-glue118-test


### PR DESCRIPTION
The devdeps environment was added in #89 but I forgot to actually use it in the CI workflow.