### PR TITLE
Prevent non-finite dot radius

### DIFF
--- a/glue_plotly/common/dotplot.py
+++ b/glue_plotly/common/dotplot.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from numpy import isfinite
 from plotly.graph_objs import Scatter
 
 from glue.core import BaseData
@@ -17,6 +18,8 @@ def dot_radius(viewer, layer_state):
         max_diam_world_v = 1
         diam_pixel_v = max_diam_world_v * height / abs(viewer_state.y_max - viewer_state.y_min)
         diam = min(diam_pixel_v, diam)
+    if not isfinite(diam):
+        diam = 1
     return diam / 2
 
 

--- a/glue_plotly/common/tests/test_dotplot.py
+++ b/glue_plotly/common/tests/test_dotplot.py
@@ -6,7 +6,7 @@ from glue_qt.app import GlueApplication
 from glue_qt.viewers.histogram import HistogramViewer
 
 from glue_plotly.common import sanitize
-from glue_plotly.common.dotplot import traces_for_layer
+from glue_plotly.common.dotplot import dot_radius, traces_for_layer
 
 from glue_plotly.viewers.histogram.viewer import PlotlyHistogramView
 from glue_plotly.viewers.histogram.dotplot_layer_artist import PlotlyDotplotLayerArtist
@@ -76,3 +76,15 @@ class TestDotplot:
 
         assert dots.y == expected_y
         assert dots.marker.size == 16  # Default figure is 640x480
+
+    def test_dot_radius_defined(self):
+        """
+        This test makes sure that we correctly get the default value for the dot radius
+        when both axes have no range.
+        """
+        self.viewer.state.x_min = 1
+        self.viewer.state.x_max = 1
+        self.viewer.state.y_min = 1
+        self.viewer.state.y_max = 1
+
+        assert dot_radius(self.viewer, self.layer.state) == 0.5


### PR DESCRIPTION
This PR updates the method that determines the dot radius for dotplot layers to prevent returning a non-finite value (for example, if axes have zero range).