### PR TITLE
Add workflow job for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -65,6 +65,20 @@ jobs:
         - windows: py311-glue119-test
         - windows: py311-glue120-test
 
+  pages:
+    needs: initial_checks
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs
+
   publish:
     needs: tests
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1


### PR DESCRIPTION
This PR adds a job to the CI workflow for deploying updates to GitHub Pages on a merge into main.