### PR TITLE
Don't show legend for image exports with only one layer

### DIFF
--- a/glue_plotly/html_exporters/jupyter/image.py
+++ b/glue_plotly/html_exporters/jupyter/image.py
@@ -28,6 +28,7 @@ class PlotlyImageBqplotExport(JupyterBaseExportTool):
         config.update(**ax)
         secondary_x = 'xaxis2' in ax
         secondary_y = 'yaxis2' in ax
+        config["showlegend"] = len(layers) > 1
 
         if secondary_x or secondary_y:
             fig = make_subplots(specs=[[{"secondary_y": True}]], horizontal_spacing=0, vertical_spacing=0)

--- a/glue_plotly/html_exporters/qt/image.py
+++ b/glue_plotly/html_exporters/qt/image.py
@@ -44,6 +44,7 @@ class PlotlyImage2DExport(Tool):
         config.update(**ax)
         secondary_x = 'xaxis2' in ax
         secondary_y = 'yaxis2' in ax
+        config["showlegend"] = len(layers) > 1
 
         if secondary_x or secondary_y:
             fig = make_subplots(specs=[[{"secondary_y": True}]], horizontal_spacing=0, vertical_spacing=0)


### PR DESCRIPTION
Currently image viewer HTML exports (both matplotlib and bqplot) always have a legend, even when there's only one layer. This PR modifies the exports to only show a legend if there are multiple layers.
