### PR TITLE
Move selection layer to top when active

### DIFF
--- a/glue_plotly/viewers/common/viewer.py
+++ b/glue_plotly/viewers/common/viewer.py
@@ -121,10 +121,15 @@ class PlotlyBaseView(IPyWidgetView):
         dy = self.state.y_max - self.state.y_min
         self.selection_layer.update(x0=x0, dx=dx, y0=y0, dy=dy)
 
-    def set_selection_active(self, visible):
-        if visible:
+    def _bring_selection_layer_to_top(self):
+        selection_layer = self.selection_layer
+        self.figure.data = [trace for trace in self.figure.data if trace is not selection_layer] + [selection_layer]
+
+    def set_selection_active(self, active):
+        if active:
             self._update_selection_layer_bounds()
-        # self.selection_layer.update(visible=visible)
+            self._bring_selection_layer_to_top()
+        # self.selection_layer.update(visible=active)
 
     def set_selection_callback(self, on_selection):
         self.selection_layer.on_selection(on_selection)


### PR DESCRIPTION
This PR ensures that the selection layer is always the top layer displayed whenever it's active. We want to make sure that this layer captures any events when it's active, and this should help with that.