### PR TITLE
Fix technical issues with Qt image exporter

### DIFF
--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -49,6 +49,14 @@ def layout_config(viewer):
                               showlegend=True)
 
 
+def get_mpl_renderer(figure):
+    if hasattr(figure.canvas, "get_renderer"):
+        return figure.canvas.get_renderer()
+    elif hasattr(figure, "_get_renderer"):
+        return figure._get_renderer()
+    return None
+
+
 def axes_data_from_mpl(viewer):
     axes_data = {}
 
@@ -58,10 +66,16 @@ def axes_data_from_mpl(viewer):
 
     for helper in axes.coords:
         ticks = helper.ticks
-        ticklabels = helper.ticklabels
+        if hasattr(helper, '_ticklabels'):
+            # We need to use the private attribute due to a bug in astropy 7
+            ticklabels = helper._ticklabels
+        else:
+            ticklabels = helper.ticklabels
         for axis in ticklabels.get_visible_axes():
             ax = 'x' if axis in ['t', 'b'] else 'y'
             ax_idx = 0 if ax == 'x' else 1
+            if not hasattr(ticks, "ticks_locs"):
+                ticks.draw(get_mpl_renderer(viewer.figure))
             locations = sorted([loc[0][ax_idx] for loc in ticks.ticks_locs[axis]])
             labels = ticklabels.text[axis]
             if ax == 'y':

--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -68,6 +68,7 @@ def axes_data_from_mpl(viewer):
         ticks = helper.ticks
         if hasattr(helper, '_ticklabels'):
             # We need to use the private attribute due to a bug in astropy 7
+            # See https://github.com/astropy/astropy/pull/17444
             ticklabels = helper._ticklabels
         else:
             ticklabels = helper.ticklabels

--- a/glue_plotly/html_exporters/qt/image.py
+++ b/glue_plotly/html_exporters/qt/image.py
@@ -89,11 +89,9 @@ class PlotlyImage2DExport(Tool):
         config.update(**ax)
         config["showlegend"] = len(layers) > 1
 
-        # worker = Worker(self._export_to_plotly, filename, checked_dictionary, config)
-        # exp_dialog = export_dialog.ExportDialog(parent=self.viewer)
-        # worker.result.connect(exp_dialog.close)
-        # worker.error.connect(exp_dialog.close)
-        # worker.start()
-        # exp_dialog.exec_()
-
-        self._export_to_plotly(filename, checked_dictionary, config)
+        worker = Worker(self._export_to_plotly, filename, checked_dictionary, config)
+        exp_dialog = export_dialog.ExportDialog(parent=self.viewer)
+        worker.result.connect(exp_dialog.close)
+        worker.error.connect(exp_dialog.close)
+        worker.start()
+        exp_dialog.exec_()


### PR DESCRIPTION
This PR fixes a couple of technical issues with the Qt image export:
* Since the export to Plotly can take a long time for the image viewer (its own issue to fix), this is one of the Qt viewers for which we wrap export in a worker and run it in a separate QThread while displaying an "Exporting to Plotly..." dialog. However, it seems that some of the matplotlib calls (used to create the Plotly layout configuration) can have issues finding the correct Qt bindings in a separate thread. Until I sort out exactly what's up with that, this PR moves the construction of the layout configuration (which isn't what can slow things down) out of the thread
* We currently set up the Plotly axes for the image export using quite a bit of inspection of the astropy/matplotlib axes of the viewers. In astropy 7.0.0, there's a bug where `ticklabels` returns the ticks rather than the labels. While we ultimately need to rework this piece of the setup as `ticklabels` is deprecated, this PR just works around the issue for now