### PR TITLE
Update masks for scatter layers

### DIFF
--- a/glue_plotly/common/base_3d.py
+++ b/glue_plotly/common/base_3d.py
@@ -92,10 +92,7 @@ def bbox_mask(viewer_state, x, y, z):
            (z >= viewer_state.z_min) & (z <= viewer_state.z_max)
 
 
-def clipped_data(viewer_state, layer_state):
-    x = layer_state.layer[viewer_state.x_att]
-    y = layer_state.layer[viewer_state.y_att]
-    z = layer_state.layer[viewer_state.z_att]
+def clipped_data(viewer_state, x, y, z):
 
     # Plotly doesn't show anything outside the bounding box
     mask = bbox_mask(viewer_state, x, y, z)

--- a/glue_plotly/common/common.py
+++ b/glue_plotly/common/common.py
@@ -134,7 +134,8 @@ def rgb_colors(layer_state, mask, cmap_att):
     return rgba_strs
 
 
-def color_info(layer_state, mask=None,
+def color_info(layer_state,
+               mask=None,
                mode_att="cmap_mode",
                cmap_att="cmap_att"):
     if getattr(layer_state, mode_att, "Fixed") == "Fixed":

--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -309,7 +309,16 @@ def traces_for_nonpixel_subset_layer(viewer_state, layer_state, full_view, trans
 def traces_for_scatter_layer(viewer_state, layer_state, hover_data=None, add_data_label=True):
     x = layer_state.layer[viewer_state.x_att].copy()
     y = layer_state.layer[viewer_state.y_att].copy()
-    mask, (x, y) = sanitize(x, y)
+    arrs = [x, y]
+    if layer_state.cmap_mode == "Linear":
+        cvals = layer_state.layer[layer_state.cmap_att].copy()
+        arrs.append(cvals)
+    if layer_state.size_mode == "Linear":
+        svals = layer_state.layer[layer_state.size_att].copy()
+        arrs.append(svals)
+
+    mask, sanitized = sanitize(*arrs)
+    x, y = sanitized[:2]
 
     marker = dict(color=color_info(layer_state),
                   opacity=layer_state.alpha,

--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -265,7 +265,16 @@ def trace_data_for_layer(viewer, layer_state, hover_data=None, add_data_label=Tr
 
     x = layer_state.layer[viewer.state.x_att].copy()
     y = layer_state.layer[viewer.state.y_att].copy()
-    mask, (x, y) = sanitize(x, y)
+    arrs = [x, y]
+    if layer_state.cmap_mode == "Linear":
+        cvals = layer_state.layer[layer_state.cmap_att].copy()
+        arrs.append(cvals)
+    if layer_state.size_mode == "Linear":
+        svals = layer_state.layer[layer_state.size_att].copy()
+        arrs.append(svals)
+
+    mask, sanitized = sanitize(*arrs)
+    x, y = sanitized[:2]
 
     legend_group = uuid4().hex
 

--- a/glue_plotly/common/scatter3d.py
+++ b/glue_plotly/common/scatter3d.py
@@ -15,7 +15,7 @@ except ImportError:
     ScatterLayerState = type(None)
 
 
-def size_info(layer_state, mask):
+def size_info(layer_state, mask, size_att="size_attribute"):
 
     # set all points to be the same size, with set scaling
     if layer_state.size_mode == 'Fixed':
@@ -23,7 +23,7 @@ def size_info(layer_state, mask):
 
     # scale size of points by set size scaling
     else:
-        s = ensure_numerical(layer_state.layer[layer_state.size_attribute][mask].ravel())
+        s = ensure_numerical(layer_state.layer[getattr(layer_state, size_att)][mask].ravel())
         s = ((s - layer_state.size_vmin) /
              (layer_state.size_vmax - layer_state.size_vmin))
         # The following ensures that the sizes are in the
@@ -121,10 +121,10 @@ def traces_for_layer(viewer_state, layer_state, hover_data=None, add_data_label=
 
     vispy_layer_state = isinstance(layer_state, ScatterLayerState)
     cmap_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    cmap_attr = "cmap_attribute" if vispy_layer_state else "cmap_att"
     size_attr = "size_attribute" if vispy_layer_state else "size_att"
     arrs = [x, y, z]
     if getattr(layer_state, cmap_mode_attr) == "Linear":
-        cmap_attr = "cmap_attribute" if vispy_layer_state else "cmap_att"
         cvals = layer_state.layer[getattr(layer_state, cmap_attr)].copy()
         arrs.append(cvals)
     if layer_state.size_mode == "Linear":
@@ -137,9 +137,9 @@ def traces_for_layer(viewer_state, layer_state, hover_data=None, add_data_label=
     x, y, z = x[mask], y[mask], z[mask]
 
     marker = dict(color=color_info(layer_state, mask=mask,
-                                   mode_att="color_mode",
-                                   cmap_att="cmap_attribute"),
-                  size=size_info(layer_state, mask),
+                                   mode_att=cmap_mode_attr,
+                                   cmap_att=cmap_attr),
+                  size=size_info(layer_state, mask, size_att=size_attr),
                   opacity=layer_state.alpha,
                   line=dict(width=0))
 

--- a/glue_plotly/common/scatter3d.py
+++ b/glue_plotly/common/scatter3d.py
@@ -6,8 +6,13 @@ from numpy import clip
 from plotly.graph_objs import Cone, Scatter3d
 from uuid import uuid4
 
-from glue_plotly.common import color_info
-from glue_plotly.common.base_3d import clipped_data
+from glue_plotly.common import color_info, sanitize
+from glue_plotly.common.base_3d import bbox_mask 
+
+try:
+    from glue_vispy_viewers.scatter.layer_state import ScatterLayerState
+except ImportError:
+    ScatterLayerState = type(None)
 
 
 def size_info(layer_state, mask):
@@ -110,7 +115,27 @@ def symbol_for_geometry(geometry: str) -> str:
 
 def traces_for_layer(viewer_state, layer_state, hover_data=None, add_data_label=True):
 
-    x, y, z, mask = clipped_data(viewer_state, layer_state)
+    x = layer_state.layer[viewer_state.x_att]
+    y = layer_state.layer[viewer_state.y_att]
+    z = layer_state.layer[viewer_state.z_att]
+
+    vispy_layer_state = isinstance(layer_state, ScatterLayerState)
+    cmap_mode_attr = "color_mode" if vispy_layer_state else "cmap_mode"
+    size_attr = "size_attribute" if vispy_layer_state else "size_att"
+    arrs = [x, y, z]
+    if getattr(layer_state, cmap_mode_attr) == "Linear":
+        cmap_attr = "cmap_attribute" if vispy_layer_state else "cmap_att"
+        cvals = layer_state.layer[getattr(layer_state, cmap_attr)].copy()
+        arrs.append(cvals)
+    if layer_state.size_mode == "Linear":
+        svals = layer_state.layer[getattr(layer_state, size_attr)].copy()
+        arrs.append(svals)
+
+    mask, _ = sanitize(*arrs)
+    bounds_mask = bbox_mask(viewer_state, x, y, z)
+    mask &= bounds_mask
+    x, y, z = x[mask], y[mask], z[mask]
+
     marker = dict(color=color_info(layer_state, mask=mask,
                                    mode_att="color_mode",
                                    cmap_att="cmap_attribute"),

--- a/glue_plotly/common/scatter3d.py
+++ b/glue_plotly/common/scatter3d.py
@@ -7,7 +7,7 @@ from plotly.graph_objs import Cone, Scatter3d
 from uuid import uuid4
 
 from glue_plotly.common import color_info, sanitize
-from glue_plotly.common.base_3d import bbox_mask 
+from glue_plotly.common.base_3d import bbox_mask
 
 try:
     from glue_vispy_viewers.scatter.layer_state import ScatterLayerState


### PR DESCRIPTION
This PR updates the masks for scatter layers (2D and 3D, including 2D scatter layers on image viewers) to take into account size and colormap attributes when relevant. This also makes sure to use the correct name for these attributes when exporting from ipyvolume viewers.