### PR TITLE
Pin Plotly version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     glue-core>=1.13.1
-    plotly
+    plotly<6.0.0a0
     chart-studio
 
 [options.extras_require]


### PR DESCRIPTION
There's a new major release of the Plotly Python package on the horizon, so this PR pins our major version until we have a chance to test against it and make updates for compatibility.
