### PR TITLE
Initialize border color

### DIFF
--- a/glue_plotly/viewers/scatter/layer_state_widget.vue
+++ b/glue_plotly/viewers/scatter/layer_state_widget.vue
@@ -57,6 +57,11 @@
                 </div>
             </template>
             <template v-else>
+               <div>
+                    <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
+                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="glue_state.size_scaling"
+                        hide-details />
+                </div>
                 <div>
                       <v-subheader class="pl-0 slider-label">fill markers</v-subheader>
                       <v-switch v-model="glue_state.fill" hide-details style="margin-top: 0" />
@@ -91,11 +96,6 @@
                             <v-color-picker v-model="glue_state.border_color"></v-color-picker>
                         </div>
                     </v-menu>
-                </div>
-                <div>
-                    <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
-                    <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="glue_state.size_scaling"
-                        hide-details />
                 </div>
             </template>
         </template>

--- a/glue_plotly/viewers/scatter/state.py
+++ b/glue_plotly/viewers/scatter/state.py
@@ -5,6 +5,6 @@ class PlotlyScatterLayerState(ScatterLayerState):
 
     border_visible = DDCProperty(False, docstring="Whether to show borders on the markers")
     border_size = DDCProperty(1, docstring="The size of the marker borders")
-    border_color = DDCProperty(docstring="The color of the marker borders")
+    border_color = DDCProperty("#000000", docstring="The color of the marker borders")
     border_color_match_layer = DDCProperty(False, docstring="If true, border color options are ignored, "
                                                             "and the border matches the layer")


### PR DESCRIPTION
This PR sets an initial default value (of black) for the scatter layer border colors, as it was possible to run into issues when this wasn't the case. Additionally, this moves the overall size scaling slider for the layer above the border control widgets.