### PR TITLE
Don't create new dot trace on a redraw

### DIFF
--- a/glue_plotly/common/dotplot.py
+++ b/glue_plotly/common/dotplot.py
@@ -23,10 +23,7 @@ def dot_radius(viewer, layer_state):
     return diam / 2
 
 
-def traces_for_layer(viewer, layer_state, add_data_label=True):
-    legend_group = uuid4().hex
-    dots_id = uuid4().hex
-
+def dot_positions(layer_state):
     x = []
     y = []
     edges, counts = layer_state.histogram
@@ -37,6 +34,15 @@ def traces_for_layer(viewer, layer_state, add_data_label=True):
         x.extend([x_i] * counts[i])
         y.extend(y_i)
 
+    return x, y
+
+
+def dots_for_layer(viewer, layer_state, add_data_label=True):
+    legend_group = uuid4().hex
+    dots_id = uuid4().hex
+
+    x, y = dot_positions(layer_state)
+
     radius = dot_radius(viewer, layer_state)
     marker = dict(color=color_info(layer_state, mask=None), size=radius)
 
@@ -44,7 +50,7 @@ def traces_for_layer(viewer, layer_state, add_data_label=True):
     if add_data_label and not isinstance(layer_state.layer, BaseData):
         name += " ({0})".format(layer_state.layer.data.label)
 
-    return [Scatter(
+    return Scatter(
         x=x,
         y=y,
         mode="markers",
@@ -52,4 +58,8 @@ def traces_for_layer(viewer, layer_state, add_data_label=True):
         name=name,
         legendgroup=legend_group,
         meta=dots_id,
-    )]
+    )
+
+
+def traces_for_layer(viewer, layer_state, add_data_label=True):
+    return [dots_for_layer(viewer, layer_state, add_data_label=add_data_label)]

--- a/glue_plotly/viewers/histogram/dotplot_layer_artist.py
+++ b/glue_plotly/viewers/histogram/dotplot_layer_artist.py
@@ -9,7 +9,7 @@ from glue.viewers.common.layer_artist import LayerArtist
 from glue.viewers.histogram.state import HistogramLayerState
 from glue_plotly.common.common import fixed_color
 
-from glue_plotly.common.dotplot import dot_radius, traces_for_layer
+from glue_plotly.common.dotplot import dot_positions, dot_radius, dots_for_layer, traces_for_layer
 
 __all__ = ["PlotlyDotplotLayerArtist"]
 
@@ -37,16 +37,30 @@ class PlotlyDotplotLayerArtist(LayerArtist):
         self.view = view
         self.bins = None
         self._dots_id = uuid4().hex
+        dots = self._create_dots()
+        self.view.figure.add_trace(dots)
 
         self._viewer_state.add_global_callback(self._update_dotplot)
         self.state.add_global_callback(self._update_dotplot)
         self.state.add_callback("zorder", self._update_zorder)
 
     def _get_dots(self):
-        return self.view.figure.select_traces(dict(meta=self._dots_id))
+        try:
+            return next(self.view.figure.select_traces(dict(meta=self._dots_id)))
+        except StopIteration:
+            dots = self._create_dots()
+            self.view.figure.add_trace(dots)
+            return dots
 
     def traces(self):
-        return self._get_dots()
+        dots = self._get_dots()
+        return [dots] if dots else []
+
+    def _create_dots(self):
+        dots = dots_for_layer(self.view, self.state, add_data_label=True)
+        dots.update(hoverinfo='all', unselected=dict(marker=dict(opacity=self.state.alpha)))
+        self._dots_id = dots.meta if dots else None
+        return dots
 
     def _calculate_histogram(self):
         try:
@@ -115,18 +129,14 @@ class PlotlyDotplotLayerArtist(LayerArtist):
                      unselected=dict(marker=dict(opacity=self.state.alpha)))
 
     def _update_data(self):
-        old_dots = self._get_dots()
-        if old_dots:
-            with self.view.figure.batch_update():
-                for trace in old_dots:
-                    self.view._remove_trace_index(trace)
-
         try:
-            dots = traces_for_layer(self.view, self.state, add_data_label=True)
-            for trace in dots:
-                trace.update(hoverinfo='all', unselected=dict(marker=dict(opacity=self.state.alpha)))
-            self._dots_id = dots[0].meta if dots else None
-            self.view.figure.add_traces(dots)
+            dots = self._get_dots()
+            if dots:
+                x, y = dot_positions(self.state)
+                dots.update(x=x, y=y)
+            else:
+                dots = self._create_dots()
+                self.view.figure.add_traces(dots)
         except (IncompatibleAttribute, ValueError):
             pass
 

--- a/glue_plotly/viewers/histogram/dotplot_layer_artist.py
+++ b/glue_plotly/viewers/histogram/dotplot_layer_artist.py
@@ -9,7 +9,7 @@ from glue.viewers.common.layer_artist import LayerArtist
 from glue.viewers.histogram.state import HistogramLayerState
 from glue_plotly.common.common import fixed_color
 
-from glue_plotly.common.dotplot import dot_positions, dot_radius, dots_for_layer, traces_for_layer
+from glue_plotly.common.dotplot import dot_positions, dot_radius, dots_for_layer
 
 __all__ = ["PlotlyDotplotLayerArtist"]
 


### PR DESCRIPTION
Currently we create a new scatter trace for a dotplot layer each time we redraw it, then remove the old trace from the viewer figure and add a new one. This is a holdover from the histogram layer artist, where we create multiple bar traces (and may have a different number on each redraw) so remaking the trace set makes more sense. However, here we're only ever making one trace, so we can just update the x and y properties of that trace.

This also currently causes problems, like described [here](https://github.com/cosmicds/hubbleds/issues/821#issuecomment-2683621503), as updating the traces can cause z-ordering issues since Plotly just shows the traces in the order that they're added to the figure. Since we aren't updating the traces with this PR, that problem should be solved now as well.