### PR TITLE
Add some missing import error guards

### DIFF
--- a/glue_plotly/html_exporters/jupyter/__init__.py
+++ b/glue_plotly/html_exporters/jupyter/__init__.py
@@ -2,5 +2,10 @@ from . import histogram  # noqa
 from . import image  # noqa
 from . import profile  # noqa
 from . import scatter2d  # noqa
-from . import scatter3d # noqa
-from . import volume  # noqa
+
+# glue-vispy-viewers
+try:
+    from . import scatter3d  # noqa
+    from . import volume  # noqa
+except ImportError:
+    pass

--- a/glue_plotly/html_exporters/qt/__init__.py
+++ b/glue_plotly/html_exporters/qt/__init__.py
@@ -1,9 +1,19 @@
 from . import scatter2d  # noqa
-from . import scatter3d  # noqa
 from . import image # noqa
 from . import histogram  # noqa
 from . import profile  # noqa
 from . import table  # noqa
-from . import dendrogram  # noqa
-from . import volume  # noqa
 from .options_state import *  # noqa
+
+# glue-qt plugins
+try:
+    from . import dendrogram  # noqa
+except ImportError:
+    pass
+
+# glue-vispy-viewers
+try:
+    from . import scatter3d  # noqa
+    from . import volume  # noqa
+except ImportError:
+    pass

--- a/glue_plotly/web/qt/__init__.py
+++ b/glue_plotly/web/qt/__init__.py
@@ -1,6 +1,3 @@
-from glue_plotly.web.export_plotly import export_dendrogram
-
-
 def setup():
 
     from glue.config import exporters
@@ -11,6 +8,7 @@ def setup():
 
     try:
         from glue_qt.plugins.dendro_viewer import DendrogramViewer
+        from glue_plotly.web.export_plotly import export_dendrogram
         DISPATCH[DendrogramViewer] = export_dendrogram
     except ImportError:
         pass


### PR DESCRIPTION
There are a few places where we're missing import guards around uses of either the vispy viewers or the glue-qt dendrogram viewer. This PR adds the necessary guards.