### PR TITLE
Fix some bugs with scatter exports

### DIFF
--- a/glue_plotly/common/scatter2d.py
+++ b/glue_plotly/common/scatter2d.py
@@ -105,10 +105,13 @@ def rectilinear_lines(layer_state, marker, x, y, legend_group=None):
 
     line = dict(dash=LINESTYLES[layer_state.linestyle], width=layer_state.linewidth)
 
+    if layer_state.cmap_mode == "Fixed":
+        line["color"] = color_info(layer_state)
+
     if layer_state.cmap_mode == 'Linear':
         line_id = uuid4().hex
         # set mode to markers and plot the colored line over it
-        rgba_strs = marker['color']
+        rgba_strs = marker['color'] if layer_state.fill else marker['line']['color']
         lc = ColoredLineCollection(x, y)
         segments = lc.get_segments()
         # generate list of indices to parse colors over

--- a/glue_plotly/html_exporters/qt/save_hover.py
+++ b/glue_plotly/html_exporters/qt/save_hover.py
@@ -48,7 +48,7 @@ class SaveHoverDialog(BaseSaveHoverDialog, QDialog):
                 item.setForeground(Qt.gray)
             else:
                 item = QListWidgetItem(component.label)
-                if self.checked_dictionary[self.state.data.label][component.label]:
+                if self.checked_dictionary[self.state.data.label].get(component.label, False):
                     item.setCheckState(Qt.Checked)
                 else:
                     item.setCheckState(Qt.Unchecked)


### PR DESCRIPTION
This PR fixes a couple of bug with the scatter exporter:
* Fix a bad interaction between unfilled markers and lines on the same layer that would cause the lines to not display
* Guard against a case where a component label is missing from an entry in the Qt hover dialog's checked dictionary