### PR TITLE
Re-pin to Plotly 5.x for now

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,8 +34,8 @@ jobs:
         # Standard tests
         - linux: py310-test
         - linux: py311-test
-        - linux: py311-test-plotly5
-        - linux: py311-test-plotly6
+        # - linux: py311-test-plotly5
+        # - linux: py311-test-plotly6
         - linux: py312-test
         - linux: py313-test
         # - linux: py313-test-devdeps
@@ -47,8 +47,8 @@ jobs:
 
         - macos: py310-test
         - macos: py311-test
-        - macos: py311-test-plotly5
-        - macos: py311-test-plotly6
+        # - macos: py311-test-plotly5
+        # - macos: py311-test-plotly6
         - macos: py312-test
         - macos: py313-test
         # - macos: py313-test-devdeps
@@ -60,8 +60,8 @@ jobs:
 
         - windows: py310-test
         - windows: py311-test
-        - windows: py311-test-plotly5
-        - windows: py311-test-plotly6
+        # - windows: py311-test-plotly5
+        # - windows: py311-test-plotly6
         - windows: py312-test
         - windows: py313-test
         # - windows: py313-test-devdeps

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     glue-core>=1.13.1
-    plotly
+    plotly<6.0.0a0
     chart-studio
 
 [options.extras_require]


### PR DESCRIPTION
While the exporters now work fine with Plotly 6.x, the viewers don't due to some issues with the updates to `FigureWidget`. From looking at Plotly issues, it seems that I may not be the only one running into these sorts of issues. So until these issues can get sorted out, this PR re-pins our Plotly dependency to 5.x for now.