### PR TITLE
Allow Plotly v6.1+

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,8 +34,8 @@ jobs:
         # Standard tests
         - linux: py310-test
         - linux: py311-test
-        # - linux: py311-test-plotly5
-        # - linux: py311-test-plotly6
+        - linux: py311-test-plotly5
+        - linux: py311-test-plotly6
         - linux: py312-test
         - linux: py313-test
         # - linux: py313-test-devdeps
@@ -47,8 +47,8 @@ jobs:
 
         - macos: py310-test
         - macos: py311-test
-        # - macos: py311-test-plotly5
-        # - macos: py311-test-plotly6
+        - macos: py311-test-plotly5
+        - macos: py311-test-plotly6
         - macos: py312-test
         - macos: py313-test
         # - macos: py313-test-devdeps
@@ -60,8 +60,8 @@ jobs:
 
         - windows: py310-test
         - windows: py311-test
-        # - windows: py311-test-plotly5
-        # - windows: py311-test-plotly6
+        - windows: py311-test-plotly5
+        - windows: py311-test-plotly6
         - windows: py312-test
         - windows: py313-test
         # - windows: py313-test-devdeps

--- a/glue_plotly/viewers/common/tools.py
+++ b/glue_plotly/viewers/common/tools.py
@@ -43,7 +43,7 @@ class PlotlySelectionMode(PlotlyDragMode):
     def deactivate(self):
         self.viewer.set_selection_callback(None)
         self.viewer.set_selection_active(False)
-        self.viewer.figure.on_edits_completed(self._clear_selection)
+        self.viewer.figure.plotly_relayout({'selections': [], 'dragmode': False})
         super().deactivate()
 
     def _clear_selection(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ packages = find:
 install_requires =
     glue-core>=1.13.1
     plotly<6.0.0a0
+    plotly>=6.1.0
     chart-studio
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,7 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     glue-core>=1.13.1
-    plotly<6.0.0a0
-    plotly>=6.1.0
+    plotly!=6.0.*
     chart-studio
 
 [options.extras_require]


### PR DESCRIPTION
With the release of Plotly v6.1, the issues that we were seeing with the Plotly viewers seem to be basically fixed. We just need the small tweak made here to get the tool selection outlines to disappear.

To account for this we also re-enable the Plotly 6 CI jobs.