### PR TITLE
Use importlib for getting package version

### DIFF
--- a/glue_plotly/__init__.py
+++ b/glue_plotly/__init__.py
@@ -1,10 +1,8 @@
+import importlib.metadata
 import os
 from contextlib import suppress
 
-from pkg_resources import DistributionNotFound, get_distribution
-
-with suppress(DistributionNotFound):
-    __version__ = get_distribution(__name__).version
+__version__ = importlib.metadata.version("glue-plotly")
 
 
 PLOTLY_LOGO = os.path.abspath(os.path.join(os.path.dirname(__file__), "logo"))


### PR DESCRIPTION
This PR updates our setting of `__version__` from using `pkg_resources` (which is now [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html)) to using `importlib`.