### PR TITLE
Add strict checks to zip calls

### DIFF
--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -198,7 +198,7 @@ def colorscale_info(layer_state, interval, contrast_bias):
     color_space = [cmap(b)[:3] for b in mapped_space]
     color_values = [tuple(float(256 * v) for v in p) for p in color_space]
     colorscale = [[0, f"rgb{color_values[0]}"]] + \
-                 [[u, f"rgb{c}"] for u, c in zip(unmapped_space, color_values)] + \
+                 [[u, f"rgb{c}"] for u, c in zip(unmapped_space, color_values, strict=True)] + \
                  [[1, f"rgb{color_values[-1]}"]]
     return mapped_bounds, colorscale
 

--- a/glue_plotly/common/image.py
+++ b/glue_plotly/common/image.py
@@ -198,7 +198,9 @@ def colorscale_info(layer_state, interval, contrast_bias):
     color_space = [cmap(b)[:3] for b in mapped_space]
     color_values = [tuple(float(256 * v) for v in p) for p in color_space]
     colorscale = [[0, f"rgb{color_values[0]}"]] + \
-                 [[u, f"rgb{c}"] for u, c in zip(unmapped_space, color_values, strict=True)] + \
+                 [[u, f"rgb{c}"] for u, c in zip(unmapped_space,
+                                                 color_values,
+                                                 strict=True)] + \
                  [[1, f"rgb{color_values[-1]}"]]
     return mapped_bounds, colorscale
 

--- a/glue_plotly/viewers/histogram/tests/test_viewer.py
+++ b/glue_plotly/viewers/histogram/tests/test_viewer.py
@@ -51,7 +51,7 @@ class TestHistogramViewer(BasePlotlyViewTests):
         assert bars.marker.opacity == 0.75
         assert bars.x == tuple(range(1, 7))
         expected_y = [3, 2, 3, 1, 0, 2]
-        assert all(a == b for a, b in zip(bars.y, expected_y))
+        assert all(a == b for a, b in zip(bars.y, expected_y, strict=True))
 
     def test_axes(self):
         x_axis = self.viewer.figure.layout.xaxis


### PR DESCRIPTION
This PR adds two explicit `strict=True` parameters to `zip` calls. In both cases it will always be true that the two iterables will be of equal length - one is from items directly constructed in a test, and in the other case both iterables are constructed from linspaces of the same size.

For a description of why we want this, see [here](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/).